### PR TITLE
Add Python 2.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+*.py[cod]
+*.sw[op]
+.cache/
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.5"
 
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then travis_retry pip install enum34 mock; fi
   - pip install -r requirements.txt
   - travis_retry python setup.py install
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 sudo: false
 
 python:
+  - "2.7"
   - "3.4"
   - "3.5"
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE README.md
+graft tests
+
+global-exclude *.py[co] .DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lightweight, super fast pythonic wrapper for [Betfair API-NG](http://docs.develo
 
 [Documentation](https://github.com/liampauling/betfairlightweight/wiki)
 
-python3 only.
+Currently tested on Python 2.7, 3.4 and 3.5.
 
 # installation
 

--- a/betfairlightweight/__init__.py
+++ b/betfairlightweight/__init__.py
@@ -4,5 +4,5 @@ from .streaming import StreamListener
 
 
 __title__ = 'betfairlightweight'
-__version__ = '0.8.5'
+__version__ = '0.9.0'
 __author__ = 'Liam Pauling'

--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -4,9 +4,10 @@ import datetime
 import os
 
 from .exceptions import PasswordError, AppKeyError, CertsError
+from .compat import FileNotFoundError
 
 
-class BaseClient:
+class BaseClient(object):
 
     IDENTITY_URLS = collections.defaultdict(
             lambda: 'https://identitysso.betfair.com/api/',
@@ -109,6 +110,9 @@ class BaseClient:
             cert_path = os.listdir(ssl_path)
         except FileNotFoundError:
             raise CertsError
+        except OSError:   # Python 2 compatability
+            raise CertsError
+
         for file in cert_path:
             ext = file.rpartition('.')[2]
             if ext in ['key', 'crt', 'pem']:

--- a/betfairlightweight/compat.py
+++ b/betfairlightweight/compat.py
@@ -1,0 +1,23 @@
+import sys
+
+
+_ver = sys.version_info
+
+#: Python 2.x?
+is_py2 = (_ver[0] == 2)
+
+#: Python 3.x?
+is_py3 = (_ver[0] == 3)
+
+
+try:
+    from builtins import FileNotFoundError
+except ImportError:
+    class FileNotFoundError(OSError):
+        pass
+
+
+if is_py2:
+    basestring = basestring
+elif is_py3:
+    basestring = (str, bytes)

--- a/betfairlightweight/endpoints/baseendpoint.py
+++ b/betfairlightweight/endpoints/baseendpoint.py
@@ -4,7 +4,7 @@ from ..exceptions import APIError
 from ..utils import check_status_code
 
 
-class BaseEndpoint:
+class BaseEndpoint(object):
 
     connect_timeout = 3.05
     read_timeout = 16
@@ -27,7 +27,7 @@ class BaseEndpoint:
         try:
             response = session.post(self.url, data=request, headers=self.client.request_headers,
                                     timeout=(self.connect_timeout, self.read_timeout))
-        except ConnectionError:
+        except session.ConnectionError:
             raise APIError(None, method, params, 'ConnectionError')
         except Exception as e:
             raise APIError(None, method, params, e)

--- a/betfairlightweight/endpoints/inplayservice.py
+++ b/betfairlightweight/endpoints/inplayservice.py
@@ -36,7 +36,7 @@ class InPlayService(BaseEndpoint):
         session = session or self.client.session
         try:
             response = session.get(url, params=params, headers=self.headers)
-        except ConnectionError:
+        except session.ConnectionError:
             raise APIError(None, method, params, 'ConnectionError')
         except Exception as e:
             raise APIError(None, method, params, e)

--- a/betfairlightweight/endpoints/racecard.py
+++ b/betfairlightweight/endpoints/racecard.py
@@ -33,7 +33,7 @@ class RaceCard(BaseEndpoint):
         try:
             response = session.get(self.url, params=self.create_req(method, params),
                                    headers=self.headers)
-        except ConnectionError:
+        except session.ConnectionError:
             raise APIError(None, method, params, 'ConnectionError')
         except Exception as e:
             raise APIError(None, method, params, e)

--- a/betfairlightweight/endpoints/streaming.py
+++ b/betfairlightweight/endpoints/streaming.py
@@ -1,7 +1,7 @@
 from ..streaming import BaseListener, BetfairStream
 
 
-class Streaming:
+class Streaming(object):
 
     def __init__(self, parent):
         """

--- a/betfairlightweight/resources/baseresource.py
+++ b/betfairlightweight/resources/baseresource.py
@@ -1,8 +1,10 @@
 import datetime
 import json
 
+from ..compat import basestring
 
-class BaseResource:
+
+class BaseResource(object):
     """
     Data structure based on a becket resource
         https://github.com/phalt/beckett
@@ -63,7 +65,7 @@ class BaseResource:
         """
         Converts value to datetime if string or int.
         """
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             try:
                 return datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
             except ValueError:

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -5,9 +5,10 @@ import ssl
 import datetime
 
 from ..exceptions import SocketError
+from ..compat import is_py3
 
 
-class BetfairStream:
+class BetfairStream(object):
     """Socket holder, connects to betfair and
     pushes any received data to listener
     """
@@ -158,7 +159,12 @@ class BetfairStream:
         till CRLF is detected.
         """
         (data, part) = ('', '')
-        while self._running and part[-2:] != bytes(self.__CRLF, encoding=self.__encoding):
+        if is_py3:
+            crlf_bytes = bytes(self.__CRLF, encoding=self.__encoding)
+        else:
+            crlf_bytes = self.__CRLF
+
+        while self._running and part[-2:] != crlf_bytes:
             part = self._socket.recv(self.buffer_size)
             if part:
                 data += part.decode(self.__encoding)

--- a/betfairlightweight/streaming/listener.py
+++ b/betfairlightweight/streaming/listener.py
@@ -1,11 +1,12 @@
+from __future__ import print_function
+
 import json
 import logging
-import time
 
 from .stream import MarketStream, OrderStream
 
 
-class BaseListener:
+class BaseListener(object):
 
     def __init__(self):
         self.market_stream = None

--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -5,7 +5,7 @@ from ..resources.streamingresources import MarketBookCache, OrderBookCache
 from ..utils import strp_betfair_integer_time
 
 
-class BaseStream:
+class BaseStream(object):
     """Separate stream class to hold market/order caches
     """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+enum34 ; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,12 @@ setup(
         author='liampauling',
         author_email='',
         description='Lightweight python wrapper for Betfair API-NG',
+        classifiers=[
+            'License :: OSI Approved :: MIT License',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            ],
         test_suite='tests'
 )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from setuptools import setup
 from betfairlightweight.__init__ import __version__
 
@@ -8,6 +10,11 @@ INSTALL_REQUIRES = [
 TEST_REQUIRES = [
     'mock'
 ]
+
+if sys.version_info < (3,4):
+    INSTALL_REQUIRES.extend([
+        'enum34',
+    ])
 
 setup(
         name='betfairlightweight',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+try:
+    import unittest.mock as mock
+except ImportError:
+    import mock

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 
 from betfairlightweight import APIClient
 from betfairlightweight.endpoints.account import Account

--- a/tests/test_baseclient.py
+++ b/tests/test_baseclient.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
+
 import datetime
 import unittest
-from unittest import mock
+from tests import mock
 
 from betfairlightweight import APIClient
 from betfairlightweight.exceptions import PasswordError, AppKeyError, CertsError

--- a/tests/test_baseendpoint.py
+++ b/tests/test_baseendpoint.py
@@ -1,6 +1,7 @@
 import unittest
 import json
-from unittest import mock
+from tests import mock
+from requests.exceptions import ConnectionError
 
 from betfairlightweight import APIClient
 from betfairlightweight.endpoints.baseendpoint import BaseEndpoint

--- a/tests/test_betfairstream.py
+++ b/tests/test_betfairstream.py
@@ -2,7 +2,7 @@ import unittest
 import socket
 import time
 import threading
-from unittest import mock
+from tests import mock
 
 from betfairlightweight.streaming.betfairstream import BetfairStream
 from betfairlightweight.exceptions import SocketError

--- a/tests/test_betting.py
+++ b/tests/test_betting.py
@@ -1,6 +1,5 @@
 import unittest
-import datetime
-from unittest import mock
+from tests import mock
 
 from tests.tools import create_mock_json
 from betfairlightweight import APIClient

--- a/tests/test_bettingresources.py
+++ b/tests/test_bettingresources.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import unittest
 import datetime
 

--- a/tests/test_inplayservice.py
+++ b/tests/test_inplayservice.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest import mock
+from tests import mock
+from requests.exceptions import ConnectionError
 
 from betfairlightweight import APIClient
 from betfairlightweight.endpoints.inplayservice import InPlayService

--- a/tests/test_keepalive.py
+++ b/tests/test_keepalive.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 from requests.exceptions import ConnectionError
 
 from tests.tools import create_mock_json

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,5 +1,7 @@
+from __future__ import print_function
+
 import unittest
-from unittest import mock
+from tests import mock
 
 from betfairlightweight.streaming.listener import BaseListener, StreamListener
 from tests.tools import create_mock_json

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 from requests.exceptions import ConnectionError
 
 from tests.tools import create_mock_json

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 from requests.exceptions import ConnectionError
 
 from tests.tools import create_mock_json

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 from requests.exceptions import ConnectionError
 
 from tests.tools import create_mock_json

--- a/tests/test_racecard.py
+++ b/tests/test_racecard.py
@@ -1,5 +1,6 @@
 import unittest
-from unittest import mock
+from tests import mock
+from requests.exceptions import ConnectionError
 
 from betfairlightweight import APIClient
 from betfairlightweight.endpoints.racecard import RaceCard

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 
 from tests.tools import create_mock_json
 from betfairlightweight import APIClient

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 
 from betfairlightweight.streaming.stream import BaseStream, MarketStream, OrderStream
 from tests.tools import create_mock_json

--- a/tests/test_streamingendpoint.py
+++ b/tests/test_streamingendpoint.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 
 from betfairlightweight import APIClient
 from betfairlightweight.endpoints.streaming import Streaming

--- a/tests/test_streamingresources.py
+++ b/tests/test_streamingresources.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+from tests import mock
 
 from betfairlightweight.resources.streamingresources import (
     MarketDefinition, OrderBookCache, OrderBookRunner, UnmatchedOrder, MarketBookCache, RunnerBook

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 import datetime
-from unittest.mock import Mock
+from mock import Mock
 
 from betfairlightweight.utils import (
     check_status_code, strp_betfair_integer_time, strp_betfair_time, price_check, update_available)

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from mock import Mock
 import json
 
 


### PR DESCRIPTION
This Pull Request adds compatibility for Python 2.7. I had to make the following modifications:

- Add `from __future__ import print_function`
- Specify base classes as `ClassName(object):` instead of `ClassName:`
- Handle `FileNotFoundError` not present in 2.7
- Change all bare `ConnectionError` to `session.ConnectionError`. It was unclear why some were this way and others weren't. Now it is consistent.
- Handle missing `unittest.mock` in 2.7
- Fix two instances of differences between `bytes`, `str` and `unicode`
- Add `enum34` to `setup.py` when necessary. 

Although the changes touch a bunch of files, I don't think they are too invasive. I'm happy to make any changes necessary to bring style/conventions into line if they aren't.