### PR TITLE
python 2.7 threading.Thread has no daemon kwarg

### DIFF
--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -42,7 +42,9 @@ class BetfairStream(object):
             self._connect()
             self.authenticate()
         if async:
-            threading.Thread(name=self.description, target=self._read_loop, daemon=False).start()
+            t = threading.Thread(name=self.description, target=self._read_loop)
+            t.daemon = False
+            t.start()
         else:
             self._read_loop()
 

--- a/tests/test_betfairstream.py
+++ b/tests/test_betfairstream.py
@@ -46,7 +46,7 @@ class BetfairStreamTest(unittest.TestCase):
         mock_read_loop.assert_called_with()
 
         self.betfair_stream.start(async=True)
-        mock_threading.Thread.assert_called_with(daemon=False, name=self.description, target=mock_read_loop)
+        mock_threading.Thread.assert_called_with(name=self.description, target=mock_read_loop)
 
         self.betfair_stream._running = False
         self.betfair_stream.start(async=False)


### PR DESCRIPTION
The daemon kwarg in threading.Thread was added in python 3 - by setting the daemon field after constructing the Thread object, the functionality remains the same, but the code is now compatible with python 2.7