### PR TITLE
Read __version__ with regex to avoid ImportError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import sys
+import re
 
 from setuptools import setup
-from betfairlightweight.__init__ import __version__
 
 
 INSTALL_REQUIRES = [
@@ -16,9 +16,13 @@ if sys.version_info < (3,4):
         'enum34',
     ])
 
+with open('betfairlightweight/__init__.py', 'r') as f:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        f.read(), re.MULTILINE).group(1)
+
 setup(
         name='betfairlightweight',
-        version=__version__,
+        version=version,
         packages=['betfairlightweight', 'betfairlightweight.endpoints',
                   'betfairlightweight.resources', 'betfairlightweight.streaming'],
         package_dir={'betfairlightweight': 'betfairlightweight'},


### PR DESCRIPTION
If I try to install from a new virtualenv (so no requests installed), I get the following error:

```
(venv) [fra@grigio test]$ pip install betfairlightweight
Collecting betfairlightweight
  Downloading betfairlightweight-0.9.3.tar.gz (63kB)
    100% |████████████████████████████████| 71kB 387kB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-RQBb_5/betfairlightweight/setup.py", line 4, in <module>
        from betfairlightweight.__init__ import __version__
      File "betfairlightweight/__init__.py", line 1, in <module>
        from .apiclient import APIClient
      File "betfairlightweight/apiclient.py", line 1, in <module>
        from .baseclient import BaseClient
      File "betfairlightweight/baseclient.py", line 1, in <module>
        import requests
    ImportError: No module named requests
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-RQBb_5/betfairlightweight/
```

This is because it tries to import requests in setup.py (by importing the library). So I replaced it by using the common pattern of reading version with a regex.