### PR TITLE
Add cert_files kwarg to APIClient

### DIFF
--- a/betfairlightweight/apiclient.py
+++ b/betfairlightweight/apiclient.py
@@ -4,8 +4,8 @@ from . import endpoints
 
 class APIClient(BaseClient):
 
-    def __init__(self, username, password=None, app_key=None, certs=None, locale=None):
-        super(APIClient, self).__init__(username, password, app_key=app_key, certs=certs, locale=locale)
+    def __init__(self, username, password=None, app_key=None, certs=None, locale=None, cert_files=None):
+        super(APIClient, self).__init__(username, password, app_key=app_key, certs=certs, locale=locale, cert_files=cert_files)
 
         self.login = endpoints.Login(self)
         self.keep_alive = endpoints.KeepAlive(self)

--- a/betfairlightweight/baseclient.py
+++ b/betfairlightweight/baseclient.py
@@ -117,9 +117,9 @@ class BaseClient(object):
         try:
             cert_path = os.listdir(ssl_path)
         except FileNotFoundError:
-            raise CertsError
+            raise CertsError(certs)
         except OSError:   # Python 2 compatability
-            raise CertsError
+            raise CertsError(certs)
 
         cert = None
         key = None
@@ -130,7 +130,7 @@ class BaseClient(object):
             elif ext == '.key':
                 key = os.path.join(ssl_path, file)
         if cert is None or key is None:
-            raise CertsError
+            raise CertsError(certs)
         return [cert, key]
 
     @property

--- a/betfairlightweight/exceptions.py
+++ b/betfairlightweight/exceptions.py
@@ -24,8 +24,8 @@ class AppKeyError(BetfairError):
 class CertsError(BetfairError):
     """Exception raised if certs folder is not found"""
 
-    def __init__(self):
-        message = 'Certificate folder not found in /certs/'
+    def __init__(self, path='/certs/'):
+        message = 'Certificate folder not found in %s' % path
         super(CertsError, self).__init__(message)
 
 

--- a/tests/test_baseclient.py
+++ b/tests/test_baseclient.py
@@ -78,6 +78,12 @@ class BaseClientTest(unittest.TestCase):
         mock_listdir.return_value = ['.DS_Store', 'client-2048.crt', 'client-2048.key']
         assert self.client.cert == ['/fail/client-2048.crt', '/fail/client-2048.key']
 
+    @mock.patch('betfairlightweight.baseclient.os.listdir')
+    def test_client_certs_missing(self, mock_listdir):
+        mock_listdir.return_value = ['.DS_Store', 'client-2048.key']
+        with self.assertRaises(CertsError):
+            print(self.client.cert)
+
     def test_set_session_token(self):
         self.client.set_session_token('session_token')
         assert self.client.session_token == 'session_token'
@@ -122,3 +128,24 @@ class BaseClientTest(unittest.TestCase):
         self.client.client_logout()
         assert self.client._login_time is None
         assert self.client.session_token is None
+
+
+class BaseClientRelativePathTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = APIClient('bf_username', 'password', 'app_key', 'fail/')
+
+    @mock.patch('betfairlightweight.baseclient.os.listdir')
+    def test_client_certs_mocked(self, mock_listdir):
+        mock_listdir.return_value = ['.DS_Store', 'client-2048.crt', 'client-2048.key']
+        assert self.client.cert == ['../fail/client-2048.crt', '../fail/client-2048.key']
+
+
+class BaseClientCertFilesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.client = APIClient('bf_username', 'password', 'app_key',
+                                cert_files=['/fail/client-2048.crt', '/fail/client-2048.key'])
+
+    def test_client_cert_files(self):
+        assert self.client.cert == ['/fail/client-2048.crt', '/fail/client-2048.key']


### PR DESCRIPTION
1. Aadded the `cert_files` kwarg, this way it doesn't break backward compatibility.
2. Added a test case for cert_files, and one for certs passed as relative path.
3. Changed `CertsError` to show the path the user passed