### PR TITLE
Merge Rory Locals

### DIFF
--- a/betfairlightweight/endpoints/account.py
+++ b/betfairlightweight/endpoints/account.py
@@ -2,40 +2,100 @@ import datetime
 
 from .baseendpoint import BaseEndpoint
 from .. import resources
-
+from ..enums import *
+from ..utils import clean_locals
 
 class Account(BaseEndpoint):
 
     URI = 'AccountAPING/v1.0/'
     connect_timeout = 6.05
 
-    def get_account_funds(self, params=None, session=None):
+    def get_account_funds(self, session=None, wallet=Wallet.UK):
+        """
+        Get account funds for specific wallet.
+
+        :param session: requests session to be used. reduces latency.
+        :type session: requests instance.
+        :param wallet: Determine whether to get info on UK or Aus wallet (deprecated UK only now).
+        :type wallet: BetfairAPI.bin.enums.Wallet
+        :returns: Available funds, risk exposure, points and discount information.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'getAccountFunds')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.AccountFunds, date_time_sent)
 
-    def get_account_details(self, params=None, session=None):
+    def get_account_details(self, session=None):
+        """
+        Get details of the current logged in account.
+
+        :param session: requests session to be used. reduces latency.
+        :type session: requests instance.
+        :returns: Personal information and account information of the logged in user.
+        """
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'getAccountDetails')
-        response = self.request(method, params, session)
+        response = self.request(method, {}, session)
         return self.process_response(response.json(), resources.AccountDetails, date_time_sent)
 
-    def get_account_statement(self, params=None, session=None):
+    def get_account_statement(self, session=None, fromRecord=0, recordCount=None, itemDateRange=None,
+                              includeItem=IncludeItem.All, wallet=Wallet.UK, locale=None):
+        """
+        Get statement of accounts transactions filtered by specified arguments.
+
+        :param session: requests session to be used. reduces latency.
+        :type session: requests instance.
+        :param fromRecord: Starting point for records returned
+        :type fromRecord: int, default 0
+        :param recordCount: Maximum number of records to return, max is 100.
+        :type recordCount: int
+        :param itemDateRange: TimeRange filter for records to include.
+        :type itemDateRange: BetfairAPI.bin.utils.create_timerange
+        :param includeItem: Filter transaction items to include.
+        :type includeItem: BetfairAPI.bin.enums.IncludeItem
+        :param wallet: Determine whether to get info on UK or Aus wallet.
+        :type wallet: BetfairAPI.bin.enums.Wallet
+        :param locale: Language used for response
+        :rtype locale: str
+        :returns: Transaction statement breakdown.
+        :rtype: Dataframe
+        :raises: BetfairAPI.bin.exceptions.ApiError
+
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'getAccountStatement')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.AccountStatementResult, date_time_sent)
 
-    def list_currency_rates(self, params=None, session=None):
+    def list_currency_rates(self, session=None, fromCurrency='GBP'):
+        """
+        Get the rates used in currency conversions from a specified currency.
+
+        :param fromCurrency: only supports GBP at the moment.
+        :type fromCurrency: str
+        :returns: Exchange rates for a list of currencies covered.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listCurrencyRates')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.CurrencyRate, date_time_sent)
 
-    def transfer_funds(self, params=None, session=None):
+    def transfer_funds(self, session=None, account_from=None, account_to=None):
+        """
+        *** DEPRECATED *** Transfer funds between aus and uk wallets.
+
+        :param account_from: Wallet to transfer from.
+        :type account_from: BetfairAPI.bin.enums.Wallet
+        :param account_to: Wallet to transfer to.
+        :type account_to: BetfairAPI.bin.enums.Wallet
+        :return: Transaction overview and updated account information.
+        """
         raise DeprecationWarning('As of 20/09/2016 AUS wallet has been removed, function still available for when '
                                  'accounts are added in 2017.')
+        # params = clean_locals(locals())
         # date_time_sent = datetime.datetime.utcnow()
         # method = '%s%s' % (self.URI, 'transferFunds')
         # response = self.request(method, params, session)

--- a/betfairlightweight/endpoints/account.py
+++ b/betfairlightweight/endpoints/account.py
@@ -13,7 +13,6 @@ class Account(BaseEndpoint):
     def get_account_funds(self, session=None, wallet=Wallet.UK):
         """
         Get account funds for specific wallet.
-
         :param session: requests session to be used. reduces latency.
         :type session: requests instance.
         :param wallet: Determine whether to get info on UK or Aus wallet (deprecated UK only now).
@@ -29,7 +28,6 @@ class Account(BaseEndpoint):
     def get_account_details(self, session=None):
         """
         Get details of the current logged in account.
-
         :param session: requests session to be used. reduces latency.
         :type session: requests instance.
         :returns: Personal information and account information of the logged in user.
@@ -43,7 +41,6 @@ class Account(BaseEndpoint):
                               includeItem=IncludeItem.All, wallet=Wallet.UK, locale=None):
         """
         Get statement of accounts transactions filtered by specified arguments.
-
         :param session: requests session to be used. reduces latency.
         :type session: requests instance.
         :param fromRecord: Starting point for records returned
@@ -61,7 +58,6 @@ class Account(BaseEndpoint):
         :returns: Transaction statement breakdown.
         :rtype: Dataframe
         :raises: BetfairAPI.bin.exceptions.ApiError
-
         """
         params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
@@ -72,7 +68,6 @@ class Account(BaseEndpoint):
     def list_currency_rates(self, session=None, fromCurrency='GBP'):
         """
         Get the rates used in currency conversions from a specified currency.
-
         :param fromCurrency: only supports GBP at the moment.
         :type fromCurrency: str
         :returns: Exchange rates for a list of currencies covered.
@@ -86,7 +81,6 @@ class Account(BaseEndpoint):
     def transfer_funds(self, session=None, account_from=None, account_to=None):
         """
         *** DEPRECATED *** Transfer funds between aus and uk wallets.
-
         :param account_from: Wallet to transfer from.
         :type account_from: BetfairAPI.bin.enums.Wallet
         :param account_to: Wallet to transfer to.
@@ -104,3 +98,4 @@ class Account(BaseEndpoint):
     @property
     def url(self):
         return '%s%s' % (self.client.api_uri, 'account/json-rpc/v1')
+

--- a/betfairlightweight/endpoints/account.py
+++ b/betfairlightweight/endpoints/account.py
@@ -13,6 +13,7 @@ class Account(BaseEndpoint):
     def get_account_funds(self, session=None, wallet=Wallet.UK):
         """
         Get account funds for specific wallet.
+
         :param session: requests session to be used. reduces latency.
         :type session: requests instance.
         :param wallet: Determine whether to get info on UK or Aus wallet (deprecated UK only now).
@@ -28,6 +29,7 @@ class Account(BaseEndpoint):
     def get_account_details(self, session=None):
         """
         Get details of the current logged in account.
+
         :param session: requests session to be used. reduces latency.
         :type session: requests instance.
         :returns: Personal information and account information of the logged in user.
@@ -41,6 +43,7 @@ class Account(BaseEndpoint):
                               includeItem=IncludeItem.All, wallet=Wallet.UK, locale=None):
         """
         Get statement of accounts transactions filtered by specified arguments.
+
         :param session: requests session to be used. reduces latency.
         :type session: requests instance.
         :param fromRecord: Starting point for records returned
@@ -68,6 +71,7 @@ class Account(BaseEndpoint):
     def list_currency_rates(self, session=None, fromCurrency='GBP'):
         """
         Get the rates used in currency conversions from a specified currency.
+
         :param fromCurrency: only supports GBP at the moment.
         :type fromCurrency: str
         :returns: Exchange rates for a list of currencies covered.
@@ -81,6 +85,7 @@ class Account(BaseEndpoint):
     def transfer_funds(self, session=None, account_from=None, account_to=None):
         """
         *** DEPRECATED *** Transfer funds between aus and uk wallets.
+
         :param account_from: Wallet to transfer from.
         :type account_from: BetfairAPI.bin.enums.Wallet
         :param account_to: Wallet to transfer to.

--- a/betfairlightweight/endpoints/betting.py
+++ b/betfairlightweight/endpoints/betting.py
@@ -2,103 +2,349 @@ import datetime
 
 from .baseendpoint import BaseEndpoint
 from .. import resources
-
+from ..filters import (MarketFilter, MarketProjection, PriceProjection)
+from ..enums import (TimeGranularity, MarketSort, OrderProjection, MatchProjection, SortDir, OrderBy, BetStatus)
+from ..utils import clean_locals
 
 class Betting(BaseEndpoint):
 
     URI = 'SportsAPING/v1.0/'
 
-    def list_event_types(self, params=None, session=None):
+    def list_event_types(self, session=None, filter=MarketFilter(), locale=None):
+        """
+        Get breakdown of market counts by sport associated with specified MarketFilter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param locale: language used for response
+        :type locale: str
+        :returns: sports names, sportsIds and market counts.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listEventTypes')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.EventTypeResult, date_time_sent)
 
-    def list_competitions(self, params=None, session=None):
+    def list_competitions(self, session=None, filter=MarketFilter(), locale=None):
+        """
+        Get breakdown of market counts by competitions associated with a given market filter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param locale: language used for response
+        :type locale: str
+        :returns: competitions info and market counts.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listCompetitions')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.CompetitionResult, date_time_sent)
 
-    def list_time_ranges(self, params=None, session=None):
+    def list_time_ranges(self, session=None, granularity=TimeGranularity.Days, filter=MarketFilter()):
+        """
+        Get breakdown of market counts grouped by specified time granularity.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param granularity: granularity at which to breakdown the market counts.
+        :type granularity: BetfairAPI.bin.utils.TimeGranularity
+        :returns: market counts grouped by granularity.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listTimeRanges')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.TimeRangeResult, date_time_sent)
 
-    def list_events(self, params=None, session=None):
+    def list_events(self, session=None, filter=MarketFilter(), locale=None):
+        """
+        Get breakdown of all events associated with a given MarketFilter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param locale: language used for response
+        :type locale: str
+        :returns: all event information.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listEvents')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.EventResult, date_time_sent)
 
-    def list_market_types(self, params=None, session=None):
+    def list_market_types(self, session=None, filter=MarketFilter(), locale=None):
+        """
+        Get dataframe markets types associated with a given MarketFilter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param locale: language used for response
+        :type locale: str
+        :returns: market counts grouped by marketType.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listMarketTypes')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.MarketTypeResult, date_time_sent)
 
-    def list_countries(self, params=None, session=None):
+    def list_countries(self, session=None, filter=MarketFilter(), locale=None):
+        """
+        Get breakdown of all market counts by country for given MarketFilter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param locale: language used for response
+        :type locale: str
+        :returns: Market counts grouped by countryCode.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listCountries')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.CountryResult, date_time_sent)
 
-    def list_venues(self, params=None, session=None):
+    def list_venues(self, session=None, filter=MarketFilter(), locale=None):
+        """
+        Get breakdown of all venue information associated with a given MarketFilter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param locale: Language used for response
+        :type locale: str
+        :returns: Market count grouped by venue.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listVenues')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.VenueResult, date_time_sent)
 
-    def list_market_catalogue(self, params=None, session=None):
+    def list_market_catalogue(self, session=None, filter=MarketFilter(), maxResults=1000, marketProjection=MarketProjection(),
+                              locale=None, sort=MarketSort.FirstStart):
+        """
+        Get breakdown of all market information associated with a given MarketFilter.
+
+        :param filter: MarketFilter to filter selected markets.
+        :type filter: BetfairAPI.bin.utils.MarketFilter
+        :param maxResults: number of results to show, max 1000.
+        :type maxResults: int
+        :param marketProjection: list of data to be included in the catalogue returned.
+        :type marketProjection: BetfairAPI.bin.utils.MarketProjection
+        :param locale: language used for response
+        :type locale: str
+        :param sort: MarketSort method to sort the results. If none Betfair rank is used.
+        :type sort: BetfairAPI.bin.enums.MarketSort
+        :returns: market data.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listMarketCatalogue')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.MarketCatalogue, date_time_sent)
 
-    def list_market_book(self, params=None, session=None):
+    def list_market_book(self, marketIds, session=None, depth=3, priceProjection=PriceProjection(),
+                         orderProjection=OrderProjection.Executable, matchProjection=MatchProjection.NoRoll,
+                         currencyCode=None, locale=None):
+        """
+        Get the order book and traded data for specified marketIds.
+
+        :param marketIds: List of market ID strings.
+        :type marketIds: list
+        :param depth: number of back and offers to be displayed
+        :type depth: int
+        :param priceProjection: dictionary of price settings.
+        :type priceProjection: BetfairAPI.bin.utils.PriceProjection
+        :param orderProjection: orders to be included in response.
+        :type orderProjection: BetfairAPI.bin.enums.OrderProjection
+        :param matchProjection: settings for order volume data to be returned.
+        :type matchProjection: BetfairAPI.bin.enums.MatchProjection
+        :param currencyCode: currency used, if none provided account default is used.
+        :type currencyCode: str
+        :param locale: language used for response, if none provided account default is used.
+        :type locale: str
+        :returns: order book data and traded data for each runner in each specified marketId
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listMarketBook')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.MarketBook, date_time_sent)
 
-    def list_current_orders(self, params=None, session=None):
+    def list_current_orders(self, session=None, betIds=None, marketIds=None, orderProjection=OrderProjection.All,
+                            dateRange=None, orderBy=OrderBy.PlaceTime, sortDir=SortDir.TimeAscending,
+                            fromRecord=0, toRecord=0):
+        """
+        Get all current orders filtered by specified arguments.
+
+        :param betIds: List of bet id strings to restrict order on. max 250 ids
+        :type betIds: list
+        :param marketIds: List of market id strings to restrict order on. max 250 ids
+        :type marketIds: list
+        :param orderProjection: Type of orders to include in results.
+        :type orderProjection: BetfairAPI.bin.enums.OrderProjection
+        :param dateRange: TimeRange (inclusive) to restrict orders.
+        :type dateRange: BetfairAPI.bin.utils.create_timerange
+        :param orderBy: Specify how orders returned are ordered.
+        :type orderBy: BetfairAPI.bin.enums.OrderType
+        :param sortDir: direction in which results are sported.
+        :type sortDir: BetfairAPI.bin.enums.SortDir
+        :param fromRecord: starting record to return.
+        :type fromRecord: int
+        :param toRecord: record to stop at, value 0 means return all up to limit. limit 1000
+        :type toRecord: int
+        :return: current order information.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listCurrentOrders')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.CurrentOrders, date_time_sent)
 
-    def list_cleared_orders(self, params=None, session=None):
+    def list_cleared_orders(self, session=None, betStatus=BetStatus.Settled, eventTypeIds=None, eventIds=None, marketIds=None,
+                            runnerIds=None, betIds=None, side=None, settledDateRange=None, groupBy=None,
+                            includeItemDescription=True, locale=None, fromRecord=0, toRecord=0):
+        """
+        Get all cleared orders filtered by specified arguments.
+
+        :param betStatus: restrict results by specific bet status.
+        :type betStatus: BetfairAPI.bin.enums.BetStatus
+        :param eventTypeIds: restrict results by eventTypeIds.
+        :type eventTypeIds: list
+        :param eventIds: restrict results by eventIds.
+        :type eventIds: list
+        :param marketIds: restrict results by marketIds.
+        :type marketIds: list
+        :param runnerIds: restrict results by runnerIds.
+        :type runnerIds: list
+        :param betIds: restrict results by betIds.
+        :type betIds: list
+        :param side: restrict results by side.
+        :type side: BetfairAPI.bin.enums.Side
+        :param settledDateRange: restrict settlement dates to include.
+        :type settledDateRange: BetfairAPI.bin.utils.create_timerange
+        :param groupBy: aggregation method for Settled betStatus.
+        :type groupBy: BetfairAPI.bin.enums.GroupBy
+        :param includeItemDescription: boolean to include item description or not.
+        :type includeItemDescription: bool
+        :param locale: language to return data in.
+        :type locale: str
+        :param fromRecord: starting record to return.
+        :type fromRecord: int
+        :param toRecord: record to stop at, value 0 means return all up to limit. limit 1000.
+        :type toRecord: int
+        :returns: All cleared orders for specified filter parameters.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listClearedOrders')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.ClearedOrders, date_time_sent)
 
-    def list_market_profit_and_loss(self, params=None, session=None):
+    def list_market_profit_and_loss(self, marketIds, session=None, includeSettledBets=False, includeBspBets=None,
+                                    netOfCommission=None):
+        """
+        Get profit and loss for a given list of markets.
+
+        :param marketIds: markets to calculate profit and loss.
+        :type marketIds: list
+        :param includeSettledBets: Option to include settled bets.
+        :type includeSettledBets: bool
+        :param includeBspBets: Option to include BSP bets.
+        :type includeBspBets: bool
+        :param netOfCommission: Option to return profit and loss net of users current commission rate and special tariffs.
+        :type netOfCommission: bool
+        :returns: profit and lost grouped by marketId.
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'listMarketProfitAndLoss')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.MarketProfitLoss, date_time_sent)
 
-    def place_orders(self, params=None, session=None):
+    def place_orders(self, marketId, OrderList, session=None, customerRef=None, marketVersion=None):
+        """
+        Place orders at exchange.
+
+
+        :param marketId: id of the market on which the orders are to be placed.
+        :type marketId: str
+        :param OrderList: list of PlaceInstructions instances which define information to create each order.
+        :type OrderList: BetfairAPI.bin.utils.PlaceInstructions
+        :param customerRef: unique string (up to 32 chars) that is used to de-dupe mistaken re-submissions.
+        :type customerRef: str
+        :param marketVersion: optional parameter of market state into which to place orders,
+                              if states don't match orders will lapse.
+        :type marketVersion: int
+        :returns: report of order status, matched, remaining and average price.
+        """
+        if not isinstance(OrderList, list):
+            raise ValueError('Orders placement must be supplied as a list of PlaceInstructions dictionaries.')
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'placeOrders')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.PlaceOrders, date_time_sent)
 
-    def cancel_orders(self, params=None, session=None):
+    def cancel_orders(self, session=None, marketId=None, instructions=None, customerRef=None):
+        """
+        Cancel or reduce orders currently at exchange.
+
+        :param marketId: id of the market as string on which the orders are to be cancelled.
+        :type marketId: str
+        :param instructions: list of dictionaries which contain betId and sizeReduction for each order. max 60.
+        :type instructions: BetfairAPI.bin.utils.CancelInfo
+        :param customerRef: unique string (up to 32 chars) that is used to de-dupe mistaken re-submissions.
+        :type customerRef: str
+        :returns: cancellation report confirming adjustments to all bets.
+
+        .. note:: if no marketId or BetInfo is supplied all bets are cancelled.
+        .. note:: if only a marketId is passed all bets on that market are cancelled.
+
+        """
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'cancelOrders')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.CancelOrders, date_time_sent)
 
-    def update_orders(self, params=None, session=None):
+    def update_orders(self, session=None, marketId=None, instructions=None, customerRef=None):
+        """
+        Update non exposure changing fields of orders at exchange.
+
+        :param marketId: id of the market as string on which the orders are to be updated.
+        :type marketId: str
+        :param instructions: list of dictionaries which contain betId and newPersistenceType for each order. max 60.
+        :type instructions: BetfairAPI.bin.utils.UpdateInfo
+        :param customerRef: unique string (up to 32 chars) that is used to de-dupe mistaken re-submissions.
+        :type customerRef: str
+        :returns: report of updated orders data.
+        """
+        if not isinstance(instructions, list):
+            raise ValueError('Order amends must be supplied as a list of UpdateInfo dictionaries.')
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'updateOrders')
         response = self.request(method, params, session)
         return self.process_response(response.json(), resources.UpdateOrders, date_time_sent)
 
-    def replace_orders(self, params=None, session=None):
+    def replace_orders(self, session=None, marketId=None, instructions=None, customerRef=None):
+        """
+        Change the price of orders at exchange.
+
+        :param marketId: id of the market as string on which the orders are to be replaced.
+        :type marketId: str
+        :param instructions: list of dictionaries which contain betId and newPrice for each order. max 60.
+        :type instructions: BetfairAPI.bin.utils.ReplaceInfo
+        :param customerRef: unique string (up to 32 chars) that is used to de-dupe mistaken re-submissions.
+        :type customerRef: str
+        :returns: report of order status, matched, remaining and average price.
+        """
+        if not isinstance(instructions, list):
+            raise ValueError('Order price amends must be supplied as a list of ReplaceInfo dictionaries.')
+        params = clean_locals(locals())
         date_time_sent = datetime.datetime.utcnow()
         method = '%s%s' % (self.URI, 'replaceOrders')
         response = self.request(method, params, session)

--- a/betfairlightweight/enums.py
+++ b/betfairlightweight/enums.py
@@ -267,3 +267,300 @@ class StreamingOrderType(Enum):
 
 class StreamingRegulatorCode(Enum):
     REG_GGC = 'GIBRALTAR REGULATOR'
+
+
+class MarketSort:
+    """
+    Specify how to sort market data received from Betfair APING.
+
+    :var MINIMUM_TRADED: Minimum traded volume
+    :var MAXIMUM_TRADED: Maximum traded volume
+    :var MINIMUM_AVAILABLE: Minimum available to match
+    :var MAXIMUM_AVAILABLE: Maximum available to match
+    :var FIRST_TO_START: The closest markets based on their expected start time
+    :var LAST_TO_START: The most distant markets based on their expected start time
+
+    """
+    MinTraded = 'MINIMUM_TRADED'
+    maxTraded = 'MAXIMUM_TRADED'
+    MinAvail = 'MINIMUM_AVAILABLE'
+    MaxAvail = 'MAXIMUM_AVAILABLE'
+    FirstStart = 'FIRST_TO_START'
+    LatestStart = 'LAST_TO_START'
+
+
+class MatchProjection:
+    """
+    How to aggregate orders.
+
+    :var NO_ROLLUP: No rollup, return raw fragments
+    :var ROLLED_UP_BY_PRICE: Rollup matched amounts by distinct matched prices per side.
+    :var ROLLED_UP_BY_AVG_PRICE: Rollup matched amounts by average matched price per side
+    """
+    NoRoll = 'NO_ROLLUP'
+    PriceRoll = 'ROLLED_UP_BY_PRICE'
+    AvgPriceRoll = 'ROLLED_UP_BY_AVG_PRICE'
+
+
+class OrderProjection:
+    """
+    Orders to include it market book data retrieved from exchange.
+
+    :var ALL: EXECUTABLE and EXECUTION_COMPLETE orders
+    :var EXECUTABLE: An order that has a remaining unmatched portion
+    :var EXECUTION_COMPLETE: An order that does not have any remaining unmatched portion
+    """
+    All = 'ALL'
+    Executable = 'EXECUTABLE'
+    Traded = 'EXECUTION_COMPLETE'
+
+
+class MarketStatus:
+    """
+
+    :var INACTIVE: The market has been created but isn't yet available.
+    :var OPEN: The market is open for betting.
+    :var SUSPENDED: The market is suspended and not available for betting.
+    :var CLOSED: The market has been settled and is no longer available for betting.
+
+    """
+    Inactive = 'INACTIVE'
+    Open = 'OPEN'
+    Suspended = 'SUSPENDED'
+    Closed = 'CLOSED'
+
+
+class RunnerStatus:
+    """
+    :var ACTIVE: ACTIVE
+    :var WINNER: WINNER
+    :var LOSER: LOSER
+    :var PLACED: The runner was placed, applies to EACH_WAY marketTypes only.
+    :var REMOVED VACANT: REMOVED_VACANT applies to Greyhounds.
+    :var REMOVED: REMOVED
+    :var HIDDEN: The selection is hidden from the market. This occurs in Horse Racing markets if runner does not hold an official entry.
+    """
+    Active = 'ACTIVE'
+    Winner = 'WINNER'
+    Loser = 'LOSER'
+    Vacant = 'REMOVED_VACANT'
+    Removed = 'REMOVED'
+    Hidden = 'HIDDEN'
+
+
+class TimeGranularity:
+    Days = 'DAYS'
+    Hours = 'HOURS'
+    Mins = 'MINUTES'
+
+
+class Side:
+    """
+    Bet side
+
+    :var BACK: To back a team, horse or outcome is to bet on the selection to win.
+    :var LAY: To lay a team, horse, or outcome is to bet on the selection to lose.
+    """
+    Back = 'BACK'
+    Lay = 'LAY'
+
+
+class RollUpModel:
+    """
+    Roll up methods to apply to orders.
+
+    :var STAKE: The volumes will be rolled up to the minimum value which is >= rollupLimit.
+    :var PAYOUT: The volumes will be rolled up to the minimum value where the payout( price * volume ) is >= rollupLimit.
+    :var MANAGED_LIABILITY: The volumes will be rolled up to the minimum value which is >= rollupLimit, until a lay price threshold.
+                            There after, the volumes will be rolled up to the minimum value such that the liability >= a minimum liability.
+    :var NONE: No rollup will be applied. However the volumes will be filtered by currency specific minimum stake unless overridden specifically for the channel.
+    """
+    Stake = 'STAKE'
+    Payout = 'PAYOUT'
+    Liability = 'MANAGED_LIABILITY'
+    NoRoll = 'NONE'
+
+
+class OrderBy:
+    """
+    Sort method to be applied to orders.
+
+    :var BY_BET: Deprecated Use BY_PLACE_TIME instead. Order by placed time, then bet id.
+    :var BY_MARKET: Order by market id, then placed time, then bet id.
+    :var BY_MATCH_TIME: Order by time of last matched fragment (if any), then placed time, then bet id.
+                        Filters out orders which have no matched date.
+                        The dateRange filter (if specified) is applied to the matched date.
+    :var BY_PLACE_TIME: Order by placed time, then bet id. This is an alias of to be deprecated BY_BET.
+                        The dateRange filter (if specified) is applied to the placed date.
+    :var BY_SETTLED_TIME: Order by time of last settled fragment (if any due to partial market settlement),
+                          then by last match time, then placed time, then bet id.
+                          Filters out orders which have not been settled.
+                          The dateRange filter (if specified) is applied to the settled date.
+    :var BY_VOID_TIME: Order by time of last voided fragment (if any), then by last match time, then placed time, then bet id.
+                       Filters out orders which have not been voided. The dateRange filter (if specified) is applied to the voided date.
+    """
+    BetId = 'BY_BET'
+    MarketId = 'BY_MARKET'
+    MatchTime = 'BY_MATCH_TIME'
+    PlaceTime = 'BY_PLACE_TIME'
+    SettleTime = 'BY_SETTLED_TIME'
+    VoidTime = 'BY_VOID_TIME'
+
+
+class SortDir:
+    """
+    Sorting by times enum.
+
+    :var EARLIEST_TO_LATEST: Order from earliest value to latest e.g. lowest betId is first in the results.
+    :var LATEST_TO_EARLIEST: Order from the latest value to the earliest e.g. highest betId is first in the results.
+    """
+    TimeAscending = 'EARLIEST_TO_LATEST'
+    TimeDescending = 'LATEST_TO_EARLIEST'
+
+
+class BetStatus:
+    """
+    Set bet status to filter for.
+
+    :var SETTLED: A matched bet that was settled normally
+    :var VOIDED: A matched bet that was subsequently voided by Betfair, before, during or after settlement
+    :var LAPSED: Unmatched bet that was cancelled by Betfair (for example at turn in play).
+    :var CANCELLED: Unmatched bet that was cancelled by an explicit customer action.
+    """
+    Settled = 'SETTLED'
+    Voided = 'VOIDED'
+    Lapsed = 'LAPSED'
+    Cancelled = 'CANCELLED'
+
+
+class GroupBy:
+    """
+    Grouping of P&L reporting
+
+    :var EVENT_TYPE: A roll up of settled P&L, commission paid and number of bet orders, on a specified event type
+    :var EVENT: A roll up of settled P&L, commission paid and number of bet orders, on a specified event
+    :var MARKET: A roll up of settled P&L, commission paid and number of bet orders, on a specified market
+    :var SIDE: An averaged roll up of settled P&L, and number of bets, on the specified side of a specified selection within a specified market, that are either settled or voided
+    :var BET: The P&L, commission paid, side and regulatory information etc, about each individual bet order
+    """
+    EventType = 'EVENT_TYPE'
+    Event = 'EVENT'
+    Market = 'MARKET'
+    Side = 'SIDE'
+    Bet = 'BET'
+
+
+class OrderType:
+    """
+    Define order type in sending orders to exchange.
+
+    :var LIMIT: A normal exchange limit order for immediate execution
+    :var LIMIT_ON_CLOSE: Limit order for the auction (SP)
+    :var MARKET_ON_CLOSE: Market order for the auction (SP)
+    """
+    LimitOrder = 'LIMIT'
+    LimitOnClose = 'LIMIT_ON_CLOSE'
+    MarketOnClose = 'MARKET_ON_CLOSE'
+
+
+class PersistenceType:
+    """
+    Description supplied to tell exchange how to handle bet.
+
+    :var LAPSE: Lapse the order when the market is turned in-play
+    :var PERSIST: Persist the order to in-play. The bet will be place automatically into the in-play market at the start of the event.
+    :var MARKET_ON_CLOSE: Put the order into the auction (SP) at turn-in-play
+    """
+    Kill = 'LAPSE'
+    Keep = 'PERSIST'
+    ClosePrice = 'MARKET_ON_CLOSE'
+
+
+class Wallet:
+    """
+    Wallet to check for accounts purposes.
+
+    :var UK: The UK Exchange wallet
+    :var AUSTRALIAN: The Australian Exchange wallet - THIS IS NOW DEPRECATED
+    """
+    UK = 'UK'
+    Aus = 'AUSTRALIAN'
+
+
+class IncludeItem:
+    """
+    Items to include for transaction reporting.
+
+    :var ALL: Include all items
+    :var DEPOSITS_WITHDRAWALS: Include payments only
+    :var EXCHANGE: Include exchange bets only
+    :var POKER_ROOM: Include poker transactions only
+
+    """
+    All = 'ALL'
+    Banking = 'DEPOSITS_WITHDRAWALS'
+    Exchange = 'EXCHANGE'
+    Poker = 'POKER_ROOM'
+
+
+class OrderStatus:
+    """
+    Status of orders sent, in processing or completed at the exchange.
+
+    :var PENDING: An asynchronous order is yet to be processed. Once the bet has been processed by the exchange (including waiting for any in-play delay),
+                  the result will be reported and available on the  Exchange Stream API and API NG. Not a valid search criteria on MarketFilter
+    :var EXECUTION_COMPLETE: An order that does not have any remaining unmatched portion.
+    :var EXECUTABLE: An order that has a remaining unmatched portion.
+    :var EXPIRED: The order is no longer available for execution due to its time in force constraint. Not a valid search criteria on MarketFilter.
+                  In the case of FILL_OR_KILL orders, this means the order has been killed because it could not be filled to your specifications.
+    """
+    Executed = 'EXECUTION_COMPLETE'
+    AtExchange = 'EXECUTABLE'
+    Expired = 'EXPIRED'
+    Pending = 'PENDING'
+
+
+class TimeInForce:
+    """
+    Used to define an order as fill and/or kill.
+
+    :var FILL_OR_KILL: Execute the transaction immediately and completely/between minFillSize and size or killed.
+    """
+    FillOrKill = 'FILL_OR_KILL'
+
+
+class BetTargetType:
+    """
+    Specify a bet to be for a specific payout or profit.
+
+    :var BACKERS_PROFIT: The payout requested minus the calculated size at which this LimitOrder is to be placed
+    :var PAYOUT: The total payout requested on a LimitOrder
+    """
+    Payout = 'PAYOUT'
+    Profit = 'BACKERS_PROFIT'
+
+
+class MarketBettingType:
+    """
+    Specifying the market type on which a bet is to be placed.
+
+    :var ODDS: Odds Market - Any market that doesn't fit any any of the below categories.
+    :var LINE: Line Market - Now Deprecated
+    :var RANGE: Range Market - Now Deprecated
+    :var ASIAN_HANDICAP_DOUBLE_LINE: Asian Handicap Market - A traditional Asian handicap market. Can be identified by marketType ASIAN_HANDICAP
+    :var ASIAN_HANDICAP_SINGLE_LINE: Asian Single Line Market - A market in which there can be 0 or multiple winners. e,.g marketType TOTAL_GOALS
+    :var FIXED_ODDS: Sportsbook Odds Market. This type is deprecated and will be removed in future releases,
+                     when Sportsbook markets will be represented as ODDS market but with a different product type.
+    """
+    Odds = 'ODDS'
+    Line = 'LINE'
+    Range = 'RANGE'
+    AsianDouble = 'ASIAN_HANDICAP_DOUBLE_LINE'
+    AsianSingle = 'ASIAN_HANDICAP_SINGLE_LINE'
+    FixedOdds = 'FIXED_ODDS'
+
+
+class Exchange:
+    """Exchange location to point to."""
+    Australia = 'AUS'
+    UK = 'UK'

--- a/betfairlightweight/filters.py
+++ b/betfairlightweight/filters.py
@@ -1,92 +1,304 @@
-
+from enums import *
 
 class BaseFilter:
-    """Base Filter"""
+    ''''''
 
 
-class MarketFilter(BaseFilter):
-
-    def __init__(self, market_ids=None, bsp_only=None, market_betting_types=None, event_type_ids=None, event_ids=None,
-                 turn_in_play_enabled=None, market_type_codes=None, venues=None, market_countries=None, text_query=None,
-                 competition_ids=None, in_play_only=None, market_start_time=None, with_orders=None):
-        self.text_query = text_query
-        self.event_type_ids = event_type_ids or []
-        self.event_ids = event_ids or []
-        self.competition_ids = competition_ids or []
-        self.market_ids = market_ids or []
-        self.venues = venues or []
-        self.bsp_only = bsp_only
-        self.turn_in_play_enabled = turn_in_play_enabled
-        self.in_play_only = in_play_only
-        self.market_betting_types = market_betting_types or []
-        self.market_type_codes = market_type_codes or []
-        self.market_countries = market_countries or []
-        self.market_start_time = market_start_time
-        self.with_orders = with_orders or []
-
-    @property
-    def serialise(self):
-        return {
-            'marketIds': self.market_ids,
-            'textQuery': self.text_query,
-            'marketBettingTypes': self.market_betting_types,
-            'eventTypeIds': self.event_type_ids,
-            'eventIds': self.event_ids,
-            'turnInPlayEnabled': self.turn_in_play_enabled,
-            'inPlayOnly': self.in_play_only,
-            'marketTypeCodes': self.market_type_codes,
-            'venues': self.venues,
-            'marketCountries': self.market_countries,
-            'bspOnly': self.bsp_only,
-            'competitionIds': self.competition_ids,
-            'marketStartTime': self.market_start_time,
-            'withOrders': self.with_orders,
-        }
-
-
-class StreamingMarketFilter(BaseFilter):
-
-    def __init__(self, market_ids=None, bsp_market=None, betting_types=None, event_type_ids=None, event_ids=None,
+def StreamingMarketFilter(market_ids=None, bsp_market=None, betting_types=None, event_type_ids=None, event_ids=None,
                  turn_in_play_enabled=None, market_types=None, venues=None, country_codes=None):
-        self.market_ids = market_ids or []
-        self.bsp_market = bsp_market
-        self.betting_types = betting_types or []
-        self.event_type_ids = event_type_ids or []
-        self.event_ids = event_ids or []
-        self.turn_in_play_enabled = turn_in_play_enabled
-        self.market_types = market_types or []
-        self.venues = venues or []
-        self.country_codes = country_codes or []
-
-    @property
-    def serialise(self):
-        return {
-            'marketIds': self.market_ids,
-            'bspMarket': self.bsp_market,
-            'bettingTypes': self.betting_types,
-            'eventTypeIds': self.event_type_ids,
-            'eventIds': self.event_ids,
-            'turnInPlayEnabled': self.turn_in_play_enabled,
-            'marketTypes': self.market_types,
-            'venues': self.venues,
-            'countryCodes': self.country_codes,
-        }
+    args = {
+        'marketIds': market_ids,
+        'bspMarket': bsp_market,
+        'bettingTypes': betting_types,
+        'eventTypeIds': event_type_ids,
+        'eventIds': event_ids,
+        'turnInPlayEnabled': turn_in_play_enabled,
+        'marketTypes': market_types,
+        'venues': venues,
+        'countryCodes': country_codes,
+    }
+    filters = dict((k, v) for k, v in args.iteritems() if v is not None)
+    return filters
 
 
-class StreamingMarketDataFilter(BaseFilter):
+def StreamingMarketDataFilter(fields=None, ladder_levels=None):
+    """
+    fields: EX_BEST_OFFERS_DISP, EX_BEST_OFFERS, EX_ALL_OFFERS, EX_TRADED,
+            EX_TRADED_VOL, EX_LTP, EX_MARKET_DEF, SP_TRADED, SP_PROJECTED
+    ladder_levels: 1->10
+    """
+    return {
+        'fields': fields,
+        'ladderLevels': ladder_levels
+    }
 
-    def __init__(self, fields=None, ladder_levels=None):
-        """
-        fields: EX_BEST_OFFERS_DISP, EX_BEST_OFFERS, EX_ALL_OFFERS, EX_TRADED,
-                EX_TRADED_VOL, EX_LTP, EX_MARKET_DEF, SP_TRADED, SP_PROJECTED
-        ladder_levels: 1->10
-        """
-        self.fields = fields or []
-        self.ladder_levels = ladder_levels
 
-    @property
-    def serialise(self):
-        return {
-            'fields': self.fields,
-            'ladderLevels': self.ladder_levels
-        }
+def MarketFilter(textQuery=None, exchangeIds=None, eventTypeIds=None, eventIds=None, competitionIds=None,
+                 marketIds=None, venues=None, bspOnly=None, turnInPlayEnabled=None, inPlayOnly=None,
+                 marketBettingTypes=None, marketCountries=None, marketTypeCodes=None, marketStartTime=None,
+                 withOrders=None):
+    """
+    Create filters to apply to market data we wish to receive.
+
+    :param textQuery: restrict markets by text associated with it, e.g name, event, comp.
+    :type textQuery: str
+    :param exchangeIds: filter market data to data pertaining to specific exchange ids.
+    :type exchangeIds: list
+    :param eventTypeIds: filter market data to data pertaining to specific event_type ids.
+    :type eventIds: list
+    :param eventIds: filter market data to data pertaining to specific event ids.
+    :type eventTypeIds: list
+    :param competitionIds: filter market data to data pertaining to specific competition ids.
+    :type competitionIds: list
+    :param marketIds: filter market data to data pertaining to specific marketIds.
+    :type marketIds: list
+    :param venues: restrict markets by venue (only horse racing has venue at the moment)
+    :type venues: list
+    :param bspOnly: restriction on bsp, not supplied will return all.
+    :type bspOnly: bool
+    :param turnInPlayEnabled: restriction on whether market will turn in play or not, not supplied returns all.
+    :type turnInPlayEnabled: bool
+    :param inPlayOnly: restriction to currently inplay, not supplied returns all.
+    :type inPlayOnly: bool
+    :param marketBettingTypes: filter market data by market betting types.
+    :type marketBettingTypes: list
+    :param marketCountries: filter market data by country codes.
+    :type marketCountries: list
+    :param marketTypeCodes: filter market data to match the type of market e.g. MATCH_ODDS.
+    :type marketTypeCodes: list
+    :param marketStartTime: filter market data by time at which it starts.
+    :type marketStartTime: BetfairAPI.bin.utils.create_timerange
+    :param withOrders: filter market data by specified order status.
+    :type withOrders: BetfairAPI.bin.enums.OrderStatus
+    :returns: filter dictionary to be applied to market data request.
+    :rtype: dict
+    """
+    args = locals()
+    filters = dict((k, v) for k, v in args.iteritems() if v is not None)
+    return filters
+
+
+def MarketProjection(COMPETITION=True, MARKET_DESCRIPTION=True, EVENT=True, EVENT_TYPE=True, RUNNER_METADATA=False,
+                     RUNNER_DESCRIPTION=True, MARKET_START_TIME=True):
+    """
+    Create MarketProjection filter list from all args passed as True.
+
+    :param COMPETITION: If not selected then the competition will not be returned with marketCatalogue.
+    :type COMPETITION: bool
+    :param MARKET_DESCRIPTION: If not selected then the description will not be returned with marketCatalogue.
+    :type MARKET_DESCRIPTION: bool
+    :param EVENT: If not selected then the event will not be returned with marketCatalogue.
+    :type EVENT: bool
+    :param EVENT_TYPE: If not selected then the eventType will not be returned with marketCatalogue.
+    :type EVENT_TYPE: bool
+    :param RUNNER_METADATA: If not selected then the runner metadata will not be returned with marketCatalogue.
+                            If selected then RUNNER_DESCRIPTION will also be returned regardless of whether
+                            it is included as a market projection.
+    :type RUNNER_METADATA: bool
+    :param RUNNER_DESCRIPTION: If not selected then the runners will not be returned with marketCatalogue.
+    :type RUNNER_DESCRIPTION: bool
+    :param MARKET_START_TIME: If not selected then the start time will not be returned with marketCatalogue.
+    :type MARKET_START_TIME: bool
+    :returns: string values of all args specified as True.
+    :rtype: list
+
+    """
+    args = locals()
+    return [k for k, v in args.iteritems() if v is True]
+
+
+def PriceData(SP_AVAILABLE=False, SP_TRADED=False, EX_BEST_OFFERS=True, EX_ALL_OFFERS=False, EX_TRADED=True):
+    """
+    Create PriceData filter list from all args passed as True.
+
+    :param SP_AVAILABLE: Amount available for the BSP auction.
+    :param SP_TRADED: Amount traded in the BSP auction.
+    :param EX_BEST_OFFERS: Only the best prices available for each runner, to requested price depth.
+    :param EX_ALL_OFFERS: trumps EX_BEST_OFFERS if both settings are present
+    :param EX_TRADED: Amount traded on the exchange.
+    :returns: string values of all args specified as True.
+    :rtype: list
+    """
+    args = locals()
+    return [k for k, v in args.iteritems() if v is True]
+
+
+def ExBestOffersOverrides(bestPricesDepth=3, rollupModel=RollUpModel.NoRoll, rollupLimit=None,
+                          rollupLiabilityThreshold=None, rollupLiabilityFactor=None):
+    """
+    Create filter to specify whether to accumulate market volume info, how deep a book to return and rollup methods if accumulation is selected.
+
+    :param bestPricesDepth: The maximum number of prices to return on each side for each runner.
+    :type bestPricesDepth: int
+    :param rollupModel: method to use to accumulate market orders.
+    :type rollupModel: BetfairAPI.bin.enums.RollUpModel
+    :param rollupLimit: The volume limit to use when rolling up returned sizes. The exact definition of the limit depends on the rollupModel.
+                        If no limit is provided it will use minimum stake
+    :type rollupLimit: int
+    :param rollupLiabilityThreshold: Only applicable when rollupModel is MANAGED_LIABILITY. The rollup model switches from
+                                     being stake based to liability based at the smallest lay price which is >= rollupLiabilityThreshold
+    :type rollupLiabilityThreshold: float
+    :param rollupLiabilityFactor: Only applicable when rollupModel is MANAGED_LIABILITY. (rollupLiabilityFactor * rollupLimit) is the
+                                  minimum liabilty the user is deemed to be comfortable with.
+                                  After the rollupLiabilityThreshold price subsequent volumes will be rolled up to minimum value such
+                                  that the liability >= the minimum liability.
+    :type rollupLiabilityFactor: int
+
+    :returns: parameters for inclusion in market data requests.
+    :rtype: dict
+
+    """
+
+    args = locals()
+    return dict((k, v) for k, v in args.iteritems() if v is not None)
+
+
+def PriceProjection(priceData=PriceData(), exBestOffersOverrides=ExBestOffersOverrides(),
+                    virtualise="true",
+                    rolloverStakes="false"):
+    """
+    Selection criteria of the returning price data.
+
+    :param priceData: PriceData filter to specify what market data we wish to receive.
+    :type priceData: BetfairAPI.bin.utils.PriceData
+    :param exBestOffersOverrides: define order book depth, rollup method.
+    :type exBestOffersOverrides: BetfairAPI.bin.utils.ExBestOffersOverrides
+    :param virtualise: whether to receive virtualised prices also.
+    :type virtualise: bool
+    :param rolloverStakes: whether to accumulate volume at each price as sum of volume at that price and all better prices.
+    :type rolloverStakes: bool
+    :returns: price data criteria for market data.
+    :rtype: dict
+    """
+    args = locals()
+    return dict((k, v) for k, v in args.iteritems() if v is not None)
+
+
+def PlaceInstructions(orderType=OrderType.LimitOrder, selectionId=None, handicap=None, side=None, limitOrder=None,
+                      limitOnCloseOrder=None, marketOnCloseOrder=None):
+    """
+    Create order instructions to place an order at exchange.
+
+    :param orderType: define type of order to place.
+    :type orderType: BetfairAPI.bin.enums.OrderType
+    :param selectionId: selection on which to place order
+    :type selectionId: int
+    :param handicap: handicap if placing order on asianhandicap type market
+    :type handicap: float
+    :param side: side of order
+    :type side: BetfairAPI.bin.enums.Side
+    :param limitOrder: if orderType is a limitOrder structure details of the order.
+    :type limitOrder: BetfairAPI.bin.utils.LimitOrder
+    :param limitOnCloseOrder: if orderType is a limitOnCloseOrder structure details of the order.
+    :type LimitOnCloseOrder: BetfairAPI.bin.utils.LimitOnCloseOrder
+    :param marketOnCloseOrder: if orderType is a marketOnCloseOrder structure details of the order.
+    :type MarketOnCloseOrder: BetfairAPI.bin.utils.MarketOnCloseOrder
+    :return: orders to place.
+    :rtype: dict
+    """
+
+    args = locals()
+    return dict((k, v) for k, v in args.iteritems() if v is not None)
+
+
+def LimitOrder(size=None, price=None, persistenceType=PersistenceType.Kill, timeInForce=None, minFillSize=None,
+               betTargetType=None, betTargetSize=None):
+    """
+    Create a limit order to send to exchange.
+
+    :param size: amount in account currency to be sent.
+    :type size: float
+    :param price: price at which the order is to be sent.
+    :type price: float
+    :param persistenceType: what happens to order at turn in play.
+    :type persistenceType: BetfairAPI.bin.enums.PersistenceType
+    :param timeInForce: specify if it is FillOrKill/FillAndKill. This value takes precedence over any PersistenceType value chosen.
+    :type timeInForce: BetfairAPI.bin.enums.TimeInForce.
+    :param minFillSize: the minimum amount to be filled for FillAndKill.
+    :type minFillSize: float
+    :param betTargetType: Specify the type of Target, bet to certain backer profit or certain payout value.
+                          Used to adjust to lower stakes if filled at better levels.
+    :type betTargetType: BetfairAPI.bin.enums.BetTargetType
+    :param betTargetSize: Size of payout of profit to bet.
+    :type betTargetSize: float
+    :returns: Order information to place a limit order.
+    :rtype: dict
+    """
+    args = locals()
+    return dict((k, v) for k, v in args.iteritems() if v is not None)
+
+
+def LimitOnCloseOrder(liability=None, price=None):
+    """
+    Create limit order for the closing auction.
+
+    :param liability: amount to bet.
+    :type liability: float
+    :param price: price at which to bet
+    :type price: float
+    :returns: Order information to place a limit on close order.
+    :rtype: dict
+
+    """
+    args = locals()
+    return dict((k, v) for k, v in args.iteritems() if v is not None)
+
+
+def MarketOnCloseOrder(liability=None):
+    """
+    Create market order to be placed in the closing auction.
+
+    :param liability: amount to bet.
+    :type liability: float
+    :returns: Order information to place a market on close order.
+    :rtype: dict
+
+    """
+    args = locals()
+    return dict((k, v) for k, v in args.iteritems() if v is not None)
+
+
+def CancelInfo(betId=None, sizeReduction=None):
+    """
+    Instruction to fully or partially cancel an order (only applies to LIMIT orders)
+
+    :param betId: identifier of the bet to cancel.
+    :type betId: str
+    :param sizeReduction: If supplied then this is a partial cancel.
+    :type sizeReduction: float
+    :returns: cancellation report detailing status, cancellation requested and actual cancellation details.
+    :rtype: Dataframe
+
+    """
+    return locals()
+
+
+def ReplaceInfo(betId=None, newPrice=None):
+    """
+    Instruction to replace a LIMIT or LIMIT_ON_CLOSE order at a new price.
+    Original order will be cancelled and a new order placed at the new price for the remaining stake.
+
+    :param betId: Unique identifier for the bet
+    :type betId: str
+    :param newPrice: The price to replace the bet at
+    :type newPrice: float
+    :returns: replace report detailing status, replace requested and actual replace details.
+    :rtype: Dataframe
+
+    """
+    return locals()
+
+
+def UpdateInfo(betId=None, newPersistenceType=None):
+    """
+    Instruction to update LIMIT bet's persistence of an order that do not affect exposure
+
+    :param betId: Unique identifier for the bet
+    :type betId: str
+    :param newPersistenceType: The new persistence type to update this bet to.
+    :type newPersistenceType: BetfairAPI.bin.enums.PersistenceType
+    :returns: update report detailing status, update requested and update details.
+    :rtype: Dataframe
+
+    """
+    return locals()

--- a/betfairlightweight/filters.py
+++ b/betfairlightweight/filters.py
@@ -35,7 +35,32 @@ def StreamingDataFields(EX_BEST_OFFERS_DISP=False, EX_BEST_OFFERS=False, EX_ALL_
 
 
 def StreamingMarketFilter(market_ids=None, bsp_market=None, betting_types=None, event_type_ids=None, event_ids=None,
-                 turn_in_play_enabled=None, market_types=None, venues=None, country_codes=None):
+                          turn_in_play_enabled=None, market_types=None, venues=None, country_codes=None):
+    """
+    Create a filter dictionary to apply to market subscriptions for streaming.
+
+    :param event_type_ids: filter markets to those pertaining to specific event_type ids.
+    :type event_type_ids: list
+    :param event_ids: filter markets to those pertaining to specific event ids.
+    :type event_ids: list
+    :param market_ids: filter markets to those pertaining to specific marketIds.
+    :type market_ids: list
+    :param venues: restrict markets by venue (only horse racing has venue at the moment)
+    :type venues: list
+    :param bettingTypes: restrict to markets that match the betting type of the market
+    :type: list
+    :param bsp_market: restriction on bsp, not supplied will return all.
+    :type bsp_market: bool
+    :param turn_in_play_enabled: restriction on whether market will turn in play or not, not supplied returns all.
+    :type turn_in_play_enabled: bool
+    :param country_codes: filter markets by country they take place in.
+    :type country_codes: list
+    :param market_types: filter markets to match the type of market e.g. MATCH_ODDS.
+    :type market_types: list
+    :returns: filter dictionary to be applied to market data request.
+    :rtype: dict
+
+    """
     args = {
         'marketIds': market_ids,
         'bspMarket': bsp_market,
@@ -206,8 +231,7 @@ def ExBestOffersOverrides(bestPricesDepth=3, rollupModel=RollUpModel.NoRoll, rol
     return dict((k, v) for k, v in args.iteritems() if v is not None)
 
 
-def PriceProjection(priceData=PriceData(), exBestOffersOverrides=ExBestOffersOverrides(),
-                    virtualise="true",
+def PriceProjection(priceData=PriceData(), exBestOffersOverrides=ExBestOffersOverrides(), virtualise="true",
                     rolloverStakes="false"):
     """
     Selection criteria of the returning price data.

--- a/betfairlightweight/filters.py
+++ b/betfairlightweight/filters.py
@@ -4,6 +4,36 @@ class BaseFilter:
     ''''''
 
 
+def StreamingDataFields(EX_BEST_OFFERS_DISP=False, EX_BEST_OFFERS=False, EX_ALL_OFFERS=True, EX_TRADED=True,
+                        EX_TRADED_VOL=False, EX_LTP=False, EX_MARKET_DEF=True, SP_TRADED=False, SP_PROJECTED=False):
+    """
+    Create PriceData filter list from all args passed as True.
+
+    :param EX_BEST_OFFERS_DISP: Best prices including virtual prices - depth is controlled by ladderLevels (1 to 10).
+                                Data fields returned: bdatb, bdatl. Data format returned: level, price, size.
+    :param EX_BEST_OFFERS: Best prices not including virtual prices - depth is controlled by ladderLevels (1 to 10).
+                           Data fields returned: batb, batl. Data format returned: level, price, size.
+    :param EX_ALL_OFFERS: Full available to BACK/LAY ladder.
+                          Data fields returned: atb, atl. Data format returned: price, size.
+    :param EX_TRADED: Full traded ladder.
+                      Data fields returned: trd. Data format returned: price, size.
+    :param EX_TRADED_VOL: Market and runner level traded volume.
+                          Data fields returned: tv. Data format returned: size.
+    :param EX_LTP: Last traded price.
+                   Data fields returned: ltp. Data format returned: price.
+    :param EX_MARKET_DEF: Send market definitions.
+                          Data fields returned: marketDefinition. Data format returned: MarketDefinition.
+    :param SP_TRADED: Starting price ladder.
+                      Data fields returned: spb, spl. Data format returned: price, size.
+    :param SP_PROJECTED: Starting price projection prices.
+                      Data fields returned: spn, spf. Data format returned: price.
+    :returns: string values of all args specified as True.
+    :rtype: list
+    """
+    args = locals()
+    return [k for k, v in args.iteritems() if v is True]
+
+
 def StreamingMarketFilter(market_ids=None, bsp_market=None, betting_types=None, event_type_ids=None, event_ids=None,
                  turn_in_play_enabled=None, market_types=None, venues=None, country_codes=None):
     args = {
@@ -21,16 +51,38 @@ def StreamingMarketFilter(market_ids=None, bsp_market=None, betting_types=None, 
     return filters
 
 
-def StreamingMarketDataFilter(fields=None, ladder_levels=None):
+def StreamingMarketDataFilter(fields=StreamingDataFields(), ladder_levels=3):
     """
-    fields: EX_BEST_OFFERS_DISP, EX_BEST_OFFERS, EX_ALL_OFFERS, EX_TRADED,
-            EX_TRADED_VOL, EX_LTP, EX_MARKET_DEF, SP_TRADED, SP_PROJECTED
-    ladder_levels: 1->10
+    Filter the level of detail to subscribe to in streaming.
+
+    :param fields: Data fields to subscribe to.
+    :type fields: StreamingDataFields
+    :param ladder_levels: the depth of ladder information to include.
+    :type ladder_levels: int(1-10)
     """
     return {
         'fields': fields,
         'ladderLevels': ladder_levels
     }
+
+
+def StreamingOrderDataFilter(includeOverallPosition=True, customerStrategyRefs=None, partitionMatchedByStrategyRef=False):
+    """
+    Filter the orders to which a stream subscribes.
+
+    :param includeOverallPosition: Returns overall / net position (OrderRunnerChange.mb / OrderRunnerChange.ml).
+    :type includeOverallPosition: bool
+    :param customerStrategyRefs: Restricts to specified customerStrategyRefs; this will filter orders and
+                                 StrategyMatchChanges accordingly (Note: overall postition is not filtered)
+    :type customerStrategyRefs: list of strings
+    :param partitionMatchedByStrategyRef: Returns strategy positions (OrderRunnerChange.smc=Map<customerStrategyRef, StrategyMatchChange>)
+                                          - these are sent in delta format as per overall position.
+    :type partitionMatchedByStrategyRef: bool
+    :return: dictionary containing filter information.
+
+    """
+    filters = dict((k, v) for k, v in locals().iteritems() if v is not None)
+    return filters
 
 
 def MarketFilter(textQuery=None, exchangeIds=None, eventTypeIds=None, eventIds=None, competitionIds=None,
@@ -105,6 +157,7 @@ def MarketProjection(COMPETITION=True, MARKET_DESCRIPTION=True, EVENT=True, EVEN
     """
     args = locals()
     return [k for k, v in args.iteritems() if v is True]
+
 
 
 def PriceData(SP_AVAILABLE=False, SP_TRADED=False, EX_BEST_OFFERS=True, EX_ALL_OFFERS=False, EX_TRADED=True):

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -4,7 +4,7 @@ import socket
 import ssl
 import datetime
 
-from ..filters import BaseFilter
+from ..filters import BaseFilter, StreamingOrderDataFilter, MarketFilter, StreamingMarketDataFilter
 from ..exceptions import SocketError
 from ..compat import is_py3
 
@@ -79,11 +79,11 @@ class BetfairStream(object):
         }
         self._send(message)
 
-    def subscribe_to_markets(self, unique_id, market_filter, market_data_filter, initial_clk=None, clk=None):
+    def subscribe_to_markets(self, unique_id, market_filter=MarketFilter(), market_data_filter=StreamingMarketDataFilter(), initial_clk=None, clk=None):
         """Market subscription request.
 
-        :param market_filter: Market filter.
-        :param market_data_filter: Market data filter.
+        :param market_filter: Market filter, can be easily configured using the MarketFilter method.
+        :param market_data_filter: Market data filter, can be easily configured using the StreamingMarketDataFilter method.
         :param unique_id: Unique id of stream.
         :param initial_clk: Sequence token for reconnect.
         :param clk: Sequence token for reconnect.
@@ -92,24 +92,25 @@ class BetfairStream(object):
             'op': 'marketSubscription',
             'id': unique_id,
             'marketFilter': market_filter.serialise if isinstance(market_filter, BaseFilter) else market_filter,
-            'marketDataFilter': market_data_filter.serialise if isinstance(
-                market_data_filter, BaseFilter) else market_data_filter,
+            'marketDataFilter': market_data_filter.serialise if isinstance(market_data_filter, BaseFilter) else market_data_filter,
             'initialClk': initial_clk,
             'clk': clk,
         }
         self.listener.register_stream(unique_id, 'marketSubscription')
         self._send(message)
 
-    def subscribe_to_orders(self, unique_id, initial_clk=None, clk=None):
+    def subscribe_to_orders(self, unique_id, order_filter=StreamingOrderDataFilter(), initial_clk=None, clk=None):
         """Order subscription request.
 
         :param unique_id: Unique id of stream.
         :param initial_clk: Sequence token for reconnect.
+        :param order_filter: apply filters to orders to which we subscribe.
         :param clk: Sequence token for reconnect.
         """
         message = {
             'op': 'orderSubscription',
             'id': unique_id,
+            'orderFilter': order_filter,
             'initialClk': initial_clk,
             'clk': clk,
         }

--- a/betfairlightweight/utils.py
+++ b/betfairlightweight/utils.py
@@ -1,4 +1,5 @@
 import datetime
+from bisect import bisect_right
 
 from .enums import MockParams
 from .exceptions import StatusCodeError
@@ -157,3 +158,15 @@ def get_bf_prices():
         elif level < 1001.0:
             level += 10.0
     return bet_levels
+
+
+def clean_locals(data):
+    """
+    Clean up locals dict, remove empty and self params.
+
+    :param data: locals dicts from a function.
+    :type data: dict
+    :returns: dict
+
+    """
+    return dict((k, v) for k, v in data.iteritems() if v is not None and k != 'self' and k != 'session')

--- a/betfairlightweight/utils.py
+++ b/betfairlightweight/utils.py
@@ -7,9 +7,9 @@ from .exceptions import StatusCodeError
 TICK_SIZES = {1.0: 0.01, 2.0: 0.02, 3.0: 0.05, 4.0: 0.1, 6.0: 0.2, 10.0: 0.5,
               20.0: 1.0, 30.0: 2.0, 50.0: 5.0, 100.0: 10.0, 1000.0: 1000}
 
+
 def check_status_code(response, codes=None):
     """Checks response.status_code is in codes
-
     :param response: Requests response
     :param codes: List of accepted codes or callable
     :raises: StatusCodeError if code invalid
@@ -39,7 +39,6 @@ def check_status_code(response, codes=None):
 
 def strp_betfair_time(datetime_string):
     """Converts Betfair string to datetime.
-
     :param datetime_string: Datetime string.
     """
     try:
@@ -52,7 +51,6 @@ def strp_betfair_time(datetime_string):
 
 def strp_betfair_integer_time(datetime_integer):
     """Converts Betfair integer to utc datetime.
-
     :param datetime_integer: Datetime integer.
     """
     try:
@@ -63,7 +61,6 @@ def strp_betfair_integer_time(datetime_integer):
 
 def price_check(data, number, key):
     """Access data from dictionary.
-
     :param data: Dict object.
     :param number: Number.
     :param key: Key.
@@ -93,24 +90,6 @@ def update_available(available, book_update, deletion_select):
 
         if not updated:
             available.append(book)
-
-
-def create_timerange(start, end):
-    """
-    Create an isoformat date range for betfair filtering.
-
-    :param start: start of time range.
-    :type start: datetime.datetime
-    :param end: end of time range.
-    :type end: datetime.datetime
-    :returns: isoformat date range.
-    :rtype: dict
-    """
-    try:
-        return {'from': start.isoformat(), 'to': end.isoformat()}
-    except:
-        raise ValueError('Failed to create isoformat dates.')
-
 
 def get_price_increment(price):
     '''
@@ -160,6 +139,23 @@ def get_bf_prices():
     return bet_levels
 
 
+def create_timerange(start, end):
+    """
+    Create an isoformat date range for betfair filtering.
+
+    :param start: start of time range.
+    :type start: datetime.datetime
+    :param end: end of time range.
+    :type end: datetime.datetime
+    :returns: isoformat date range.
+    :rtype: dict
+    """
+    try:
+        return {'from': start.isoformat(), 'to': end.isoformat()}
+    except:
+        raise ValueError('Failed to create isoformat dates.')
+
+
 def clean_locals(data):
     """
     Clean up locals dict, remove empty and self params.
@@ -170,3 +166,4 @@ def clean_locals(data):
 
     """
     return dict((k, v) for k, v in data.iteritems() if v is not None and k != 'self' and k != 'session')
+

--- a/betfairlightweight/utils.py
+++ b/betfairlightweight/utils.py
@@ -3,6 +3,8 @@ import datetime
 from .enums import MockParams
 from .exceptions import StatusCodeError
 
+TICK_SIZES = {1.0: 0.01, 2.0: 0.02, 3.0: 0.05, 4.0: 0.1, 6.0: 0.2, 10.0: 0.5,
+              20.0: 1.0, 30.0: 2.0, 50.0: 5.0, 100.0: 10.0, 1000.0: 1000}
 
 def check_status_code(response, codes=None):
     """Checks response.status_code is in codes
@@ -90,3 +92,68 @@ def update_available(available, book_update, deletion_select):
 
         if not updated:
             available.append(book)
+
+
+def create_timerange(start, end):
+    """
+    Create an isoformat date range for betfair filtering.
+
+    :param start: start of time range.
+    :type start: datetime.datetime
+    :param end: end of time range.
+    :type end: datetime.datetime
+    :returns: isoformat date range.
+    :rtype: dict
+    """
+    try:
+        return {'from': start.isoformat(), 'to': end.isoformat()}
+    except:
+        raise ValueError('Failed to create isoformat dates.')
+
+
+def get_price_increment(price):
+    '''
+    Get the tick size given a reference price.
+
+    :param price: reference price.
+    :type price: float
+    :returns: Tick size increment.
+    :rtype: float
+    '''
+    price_list = sorted(TICK_SIZES.keys())
+    closest_price = price_list[bisect_right(price_list, price)-1]
+    return TICK_SIZES.get(closest_price)
+
+
+def get_bf_prices():
+    '''
+    Get all tradeable prices for betfair.
+
+    :returns: list of all prices tradeable on betfair.
+    :rtype: list
+    '''
+    level = 1.01
+    bet_levels = []
+    while level <= 1000.0:
+        bet_levels.append(float(str(level)))
+        if level < 1.995:
+            level += 0.01
+        elif level < 2.99:
+            level += 0.02
+        elif level < 3.99:
+            level += 0.05
+        elif level < 5.99:
+            level += 0.1
+        elif level < 9.99:
+            level += 0.2
+        elif level < 19.99:
+            level += 0.5
+        elif level < 29.99:
+            level += 1.0
+        elif level < 49.99:
+            level += 2.0
+        elif level < 99.99:
+            level += 5.0
+        elif level < 1001.0:
+            level += 10.0
+    return bet_levels

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -8,38 +8,22 @@ class MarketFilterTest(unittest.TestCase):
     def setUp(self):
         self.market_filter = MarketFilter()
 
-    def test_init(self):
-        assert self.market_filter.text_query is None
-        assert self.market_filter.event_type_ids == []
-        assert self.market_filter.event_ids == []
-        assert self.market_filter.competition_ids == []
-        assert self.market_filter.market_ids == []
-        assert self.market_filter.venues == []
-        assert self.market_filter.bsp_only is None
-        assert self.market_filter.turn_in_play_enabled is None
-        assert self.market_filter.in_play_only is None
-        assert self.market_filter.market_betting_types == []
-        assert self.market_filter.market_type_codes == []
-        assert self.market_filter.market_countries == []
-        assert self.market_filter.market_start_time is None
-        assert self.market_filter.with_orders == []
-
-    def test_serialise(self):
-        assert self.market_filter.serialise == {
-            'marketIds': [],
+    def test_return(self):
+        assert self.market_filter == {
+            'marketIds': None,
             'textQuery': None,
-            'marketBettingTypes': [],
-            'eventTypeIds': [],
-            'eventIds': [],
+            'marketBettingTypes': None,
+            'eventTypeIds': None,
+            'eventIds': None,
             'turnInPlayEnabled': None,
             'inPlayOnly': None,
-            'marketTypeCodes': [],
-            'venues': [],
-            'marketCountries': [],
+            'marketTypeCodes': None,
+            'venues': None,
+            'marketCountries': None,
             'bspOnly': None,
-            'competitionIds': [],
+            'competitionIds': None,
             'marketStartTime': None,
-            'withOrders': [],
+            'withOrders': None,
         }
 
 
@@ -48,19 +32,8 @@ class StreamingMarketFilterTest(unittest.TestCase):
     def setUp(self):
         self.market_filter = StreamingMarketFilter()
 
-    def test_init(self):
-        assert self.market_filter.market_ids == []
-        assert self.market_filter.bsp_market is None
-        assert self.market_filter.betting_types == []
-        assert self.market_filter.event_type_ids == []
-        assert self.market_filter.event_ids == []
-        assert self.market_filter.turn_in_play_enabled is None
-        assert self.market_filter.market_types == []
-        assert self.market_filter.venues == []
-        assert self.market_filter.country_codes == []
-
-    def test_serialise(self):
-        assert self.market_filter.serialise == {
+    def test_return(self):
+        assert self.market_filter == {
             'marketIds': [],
             'bspMarket': None,
             'bettingTypes': [],
@@ -80,12 +53,8 @@ class StreamingMarketDataFilterTest(unittest.TestCase):
         self.ladder_levels = 69
         self.market_filter = StreamingMarketDataFilter(self.fields, self.ladder_levels)
 
-    def test_init(self):
-        assert self.market_filter.fields == self.fields
-        assert self.market_filter.ladder_levels == self.ladder_levels
-
-    def test_serialise(self):
-        assert self.market_filter.serialise == {
+    def test_return(self):
+        assert self.market_filter == {
             'fields': self.fields,
             'ladderLevels': self.ladder_levels
         }


### PR DESCRIPTION
Merging some nice functionality from a local betfair wrapper.

 - Move all account and betting endpoints to have params named in method rather than just a params arg.

 - Include doc strings for all account and betting endpoints.

 - Extend enums to cover all betting enums and include doc strings with variable explanations.

 - Extend subscribe_to_orders method to accept orderFilter, usefult for distinguishing order to subscribe to by strategyRef.

 - Add some commonly used methods to utils.

