### PR TITLE
Compute stream latency directly from unix timestamp

### DIFF
--- a/betfairlightweight/streaming/stream.py
+++ b/betfairlightweight/streaming/stream.py
@@ -1,8 +1,8 @@
 import datetime
+import time
 import logging
 
 from ..resources.streamingresources import MarketBookCache, OrderBookCache
-from ..utils import strp_betfair_integer_time
 
 
 class BaseStream(object):
@@ -70,7 +70,7 @@ class BaseStream(object):
 
     @staticmethod
     def _calc_latency(publish_time):
-        return (datetime.datetime.utcnow() - strp_betfair_integer_time(publish_time)).total_seconds()
+        return time.time() - publish_time / 1e3
 
     def __str__(self):
         return '<BaseStream>'

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -77,8 +77,12 @@ class BaseStreamTest(unittest.TestCase):
         self.stream._update_clk({'clk': 123})
         assert self.stream._clk == 123
 
-    def test_calc_latency(self):
-        assert self.stream._calc_latency(1234) is not None
+
+    @mock.patch('time.time', return_value=1485554805.107185)
+    def test_calc_latency(self, mock_time):
+        pt = 1485554796455
+        assert self.stream._calc_latency(pt) is not None
+        assert abs(self.stream._calc_latency(pt) - 8.652184) < 1e-5
 
     def test_str(self):
         assert str(self.stream) == '<BaseStream>'


### PR DESCRIPTION
Makes the function around 10x faster on microbenchmarks.
Since it's something that can be potentially be called lots of times, I thought it was worth tweaking it a bit to avoid the int -> dt -> int conversions.


Before:

```
def latency1(dt)
    return (datetime.datetime.utcnow() - datetime.datetime.utcfromtimestamp(dt / 1e3)).total_seconds()

# In [28]: %timeit latency(x)
# The slowest run took 9.40 times longer than the fastest. This could mean that an intermediate result is being cached.
# 1000000 loops, best of 3: 1.29 µs per loop
```

After:

```
def latency2(dt):
    return time.time() - dt /1e3

# In [29]: %timeit latency2(x)
# The slowest run took 9.60 times longer than the fastest. This could mean that an intermediate result is being cached.
# 1000000 loops, best of 3: 194 ns per loop


```