### PR TITLE
Configure logging

### DIFF
--- a/betfairlightweight/__init__.py
+++ b/betfairlightweight/__init__.py
@@ -1,9 +1,21 @@
+import logging
+
 from .apiclient import APIClient
 from .exceptions import BetfairError
-from .streaming import StreamListener
 from .filters import MarketFilter, StreamingMarketFilter, StreamingMarketDataFilter
+from .streaming import StreamListener
 
 
 __title__ = 'betfairlightweight'
 __version__ = '0.9.9'
 __author__ = 'Liam Pauling'
+
+# Set default logging handler to avoid "No handler found" warnings.
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())

--- a/betfairlightweight/streaming/listener.py
+++ b/betfairlightweight/streaming/listener.py
@@ -5,6 +5,8 @@ import logging
 
 from .stream import MarketStream, OrderStream
 
+logger = logging.getLogger(__name__)
+
 
 class BaseListener(object):
 
@@ -15,18 +17,18 @@ class BaseListener(object):
 
     def register_stream(self, unique_id, operation):
         if operation == 'authentication':
-            logging.info('[Listener: %s]: %s' % (unique_id, operation))
+            logger.info('[Listener: %s]: %s' % (unique_id, operation))
 
         elif operation == 'marketSubscription':
             if self.market_stream is not None:
-                logging.warning('[Listener: %s]: marketSubscription stream already registered, replacing data' %
-                                unique_id)
+                logger.warning('[Listener: %s]: marketSubscription stream already registered, replacing data' %
+                               unique_id)
             self.market_stream = self._add_stream(unique_id, operation)
 
         elif operation == 'orderSubscription':
             if self.order_stream is not None:
-                logging.warning('[Listener: %s]: orderSubscription stream already registered, replacing data' %
-                                unique_id)
+                logger.warning('[Listener: %s]: orderSubscription stream already registered, replacing data' %
+                               unique_id)
             self.order_stream = self._add_stream(unique_id, operation)
 
     def on_data(self, raw_data):
@@ -63,7 +65,7 @@ class StreamListener(BaseListener):
         try:
             data = json.loads(raw_data)
         except ValueError:
-            logging.error('value error: %s' % raw_data)
+            logger.error('value error: %s' % raw_data)
             return
         unique_id = data.get('id')
 
@@ -84,7 +86,7 @@ class StreamListener(BaseListener):
         :param data: Received data
         """
         self.connection_id = data.get('connectionId')
-        logging.info('[Connect: %s]: connection_id: %s' % (unique_id, self.connection_id))
+        logger.info('[Connect: %s]: connection_id: %s' % (unique_id, self.connection_id))
 
     @staticmethod
     def _on_status(data, unique_id):
@@ -93,7 +95,7 @@ class StreamListener(BaseListener):
         :param data: Received data
         """
         status_code = data.get('statusCode')
-        logging.info('[Subscription: %s]: %s' % (unique_id, status_code))
+        logger.info('[Subscription: %s]: %s' % (unique_id, status_code))
 
     def _on_change_message(self, data, unique_id):
         change_type = data.get('ct', 'UPDATE')
@@ -104,7 +106,7 @@ class StreamListener(BaseListener):
         else:
             stream = self.order_stream
 
-        logging.debug('[Subscription: %s]: %s: %s' % (unique_id, change_type, data))
+        logger.debug('[Subscription: %s]: %s: %s' % (unique_id, change_type, data))
 
         if change_type == 'SUB_IMAGE':
             stream.on_subscribe(data)
@@ -134,7 +136,7 @@ class StreamListener(BaseListener):
         :return: True if error present
         """
         if data.get('statusCode') == 'FAILURE':
-            logging.error('[Subscription: %s] %s: %s' % (unique_id, data.get('errorCode'), data.get('errorMessage')))
+            logger.error('[Subscription: %s] %s: %s' % (unique_id, data.get('errorCode'), data.get('errorMessage')))
             if data.get('connectionClosed'):
                 return True
 


### PR DESCRIPTION
Top level library logger set up with a NullHandler following the convention of the `requests` library as mentioned [here](http://docs.python-guide.org/en/latest/writing/logging/#logging-in-a-library).

Existing `logging.*` statements replaced with individual `logger` statements which are instantiated in the modules where they are used.

Users can now configure logging output by getting and configuring the logger with name `betfairlightweight`.
