### PR TITLE
Make test_baseclient tests involving paths cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+
+.DS_Store

--- a/tests/test_baseclient.py
+++ b/tests/test_baseclient.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import datetime
+import os
 import unittest
 from tests import mock
 
@@ -130,22 +131,26 @@ class BaseClientTest(unittest.TestCase):
         assert self.client.session_token is None
 
 
+def normpaths(p):
+    return list(map(os.path.normpath, p))
+
+
 class BaseClientRelativePathTest(unittest.TestCase):
 
     def setUp(self):
-        self.client = APIClient('bf_username', 'password', 'app_key', 'fail/')
+        self.client = APIClient('bf_username', 'password', 'app_key', os.path.normpath('fail/'))
 
     @mock.patch('betfairlightweight.baseclient.os.listdir')
     def test_client_certs_mocked(self, mock_listdir):
-        mock_listdir.return_value = ['.DS_Store', 'client-2048.crt', 'client-2048.key']
-        assert self.client.cert == ['../fail/client-2048.crt', '../fail/client-2048.key']
+        mock_listdir.return_value = normpaths(['.DS_Store', 'client-2048.crt', 'client-2048.key'])
+        assert self.client.cert == normpaths(['../fail/client-2048.crt', '../fail/client-2048.key'])
 
 
 class BaseClientCertFilesTest(unittest.TestCase):
 
     def setUp(self):
         self.client = APIClient('bf_username', 'password', 'app_key',
-                                cert_files=['/fail/client-2048.crt', '/fail/client-2048.key'])
+                                cert_files=normpaths(['/fail/client-2048.crt', '/fail/client-2048.key']))
 
     def test_client_cert_files(self):
-        assert self.client.cert == ['/fail/client-2048.crt', '/fail/client-2048.key']
+        assert self.client.cert == normpaths(['/fail/client-2048.crt', '/fail/client-2048.key'])


### PR DESCRIPTION
I was finally getting around to having another go at building a conda-forge package for `betfairlightweight` and noticed that although the initial issue appears to have been resolved, subsequent changes to the tests were causing failures on Windows due to differences in path separator conventions. This PR makes tests involving paths platform-independent. 

Once these changes have been approved and merged and a new release is made, I think we should be good to go on conda-forge. 

I have access to both OSX and Windows machines to test and fix issues like this, but it would be helpful to add a Windows-based CI to run the tests automatically. See https://github.com/liampauling/betfairlightweight/issues/47

