### PR TITLE
Call stop before raising SocketError in _read_loop

### DIFF
--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -153,12 +153,9 @@ class BetfairStream(object):
                     for received_data in received_data_split:
                         if received_data:
                             self._data(received_data)
-            except socket.timeout as e:
+            except (socket.timeout, socket.error) as e:
                 self.stop()
-                raise SocketError('[Connect: %s]: Socket timeout, %s' % (self.unique_id, e))
-            except socket.error as e:
-                self.stop()
-                raise SocketError('[Connect: %s]: Socket error, %s' % (self.unique_id, e))
+                raise SocketError('[Connect: %s]: Socket %s' % (self.unique_id, e))
 
     def _receive_all(self):
         """Whilst socket is running receives data from socket,

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -54,6 +54,13 @@ class BetfairStream(object):
         """
         self._running = False
 
+        if self._socket is not None and not self._socket._closed:
+            try:
+                self._socket.shutdown(2)
+            except OSError:
+                pass
+            self._socket.close()
+
     def authenticate(self, unique_id=None):
         """Authentication request.
 
@@ -150,13 +157,6 @@ class BetfairStream(object):
                 raise SocketError('[Connect: %s]: Socket timeout, %s' % (self.unique_id, e))
             except socket.error as e:
                 raise SocketError('[Connect: %s]: Socket error, %s' % (self.unique_id, e))
-
-        if not self._socket._closed:
-            try:
-                self._socket.shutdown(2)
-            except OSError:
-                pass
-            self._socket.close()
 
     def _receive_all(self):
         """Whilst socket is running receives data from socket,

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -50,7 +50,7 @@ class BetfairStream(object):
             self._read_loop()
 
     def stop(self):
-        """Stops read loop which closes socket
+        """Stops read loop and closes socket if it has been created.
         """
         self._running = False
 

--- a/betfairlightweight/streaming/betfairstream.py
+++ b/betfairlightweight/streaming/betfairstream.py
@@ -154,8 +154,10 @@ class BetfairStream(object):
                         if received_data:
                             self._data(received_data)
             except socket.timeout as e:
+                self.stop()
                 raise SocketError('[Connect: %s]: Socket timeout, %s' % (self.unique_id, e))
             except socket.error as e:
+                self.stop()
                 raise SocketError('[Connect: %s]: Socket error, %s' % (self.unique_id, e))
 
     def _receive_all(self):

--- a/tests/test_betfairstream.py
+++ b/tests/test_betfairstream.py
@@ -141,8 +141,9 @@ class BetfairStreamTest(unittest.TestCase):
         assert self.betfair_stream.datetime_last_received is not None
         assert self.betfair_stream.receive_count > 0
 
+    @mock.patch('betfairlightweight.streaming.betfairstream.BetfairStream.stop')
     @mock.patch('betfairlightweight.streaming.betfairstream.BetfairStream._receive_all')
-    def test_read_loop_error(self, mock_receive_all):
+    def test_read_loop_error(self, mock_receive_all, mock_stop):
         mock_socket = mock.Mock()
         self.betfair_stream._socket = mock_socket
         self.betfair_stream._running = True


### PR DESCRIPTION
I've moved the socket cleanup code into `stop` and called it before raising SocketError.

I had to modify one of the tests since it was expecting a SocketError but the stop code was causing a different exception to be thrown as the socket was mocked and it was trying to call a non-existent method.

Maybe it would have been better to mock the `shutdown` and `close` methods on the socket instead?
