### PR TITLE
 Starting price additions and bug fixes

### DIFF
--- a/betfairlightweight/__init__.py
+++ b/betfairlightweight/__init__.py
@@ -6,7 +6,7 @@ from .streaming import StreamListener
 from . import filters
 
 __title__ = 'betfairlightweight'
-__version__ = '1.1.4'
+__version__ = '1.1.5'
 __author__ = 'Liam Pauling'
 
 # Set default logging handler to avoid "No handler found" warnings.

--- a/betfairlightweight/resources/streamingresources.py
+++ b/betfairlightweight/resources/streamingresources.py
@@ -234,6 +234,20 @@ class RunnerBook(object):
                     for volume in sorted(self.best_available_to_lay, key=itemgetter(0))]
         return []
 
+    @property
+    def serialise_starting_price_back(self):
+        if self.starting_price_back:
+            return [{'price': volume[0], 'size': volume[1]}
+                    for volume in sorted(self.starting_price_back, key=itemgetter(0))]
+        return []
+
+    @property
+    def serialise_starting_price_lay(self):
+        if self.starting_price_lay:
+            return [{'price': volume[0], 'size': volume[1]}
+                    for volume in sorted(self.starting_price_lay, key=itemgetter(0))]
+        return []
+
     def serialise(self, status):
         return {
             'status': status,
@@ -241,6 +255,12 @@ class RunnerBook(object):
                 'tradedVolume': self.serialise_traded_volume,
                 'availableToBack': self.serialise_available_to_back,
                 'availableToLay': self.serialise_available_to_lay
+            },
+            'sp': {
+                'nearPrice': self.starting_price_near,
+                'farPrice': self.starting_price_far,
+                'backStakeTaken': self.serialise_starting_price_back,
+                'layLiabilityTaken': self.serialise_starting_price_lay
             },
             'adjustmentFactor': None,
             'lastPriceTraded': self.last_price_traded,
@@ -285,9 +305,9 @@ class MarketBookCache(BaseResource):
                     if new_data.get('tv'):
                         runner.total_matched = new_data.get('tv')
                     if new_data.get('spn'):
-                        runner.spn = new_data.get('spn')
+                        runner.starting_price_near = new_data.get('spn')
                     if new_data.get('spf'):
-                        runner.spf = new_data.get('spf')
+                        runner.starting_price_far = new_data.get('spf')
                     if new_data.get('trd'):
                         runner.update_traded(new_data.get('trd'))
                     if new_data.get('atb'):
@@ -305,7 +325,7 @@ class MarketBookCache(BaseResource):
                     if new_data.get('spb'):
                         runner.update_starting_price_back(new_data.get('spb'))
                     if new_data.get('spl'):
-                        runner.update_starting_price_back(new_data.get('spl'))
+                        runner.update_starting_price_lay(new_data.get('spl'))
                 else:
                     self.runners.append(RunnerBook(**new_data))
 

--- a/tests/test_streamingresources.py
+++ b/tests/test_streamingresources.py
@@ -367,3 +367,30 @@ class TestRunnerBook(unittest.TestCase):
 
         self.runner_book.update_starting_price_lay(book_update)
         mock_update_available.assert_called_with(current, book_update, 1)
+
+    def test_serialise(self):
+        traded_update = [[18.4, 1.1]]
+        self.runner_book.update_traded(traded_update)
+        back_update = [[18.5, 1.2]]
+        self.runner_book.update_available_to_back(back_update)
+        lay_update = [[18.6, 1.3]]
+        self.runner_book.update_available_to_lay(lay_update)
+
+        sp_back_update = [[18.7, 1.4]]
+        self.runner_book.update_starting_price_back(sp_back_update)
+        sp_lay_update = [[18.8, 1.5]]
+        self.runner_book.update_starting_price_lay(sp_lay_update)
+
+        serialise_d = self.runner_book.serialise(None)
+        assert serialise_d.keys() == \
+            ['status', 'totalMatched', 'adjustmentFactor', 'ex', 'handicap',
+             'lastPriceTraded', 'sp', 'selectionId']
+
+        ex = serialise_d['ex']
+        assert ex['tradedVolume'][0]['price'] == traded_update[0][0]
+        assert ex['availableToBack'][0]['price'] == back_update[0][0]
+        assert ex['availableToLay'][0]['price'] == lay_update[0][0]
+
+        sp = serialise_d['sp']
+        assert sp['backStakeTaken'][0]['price'] == sp_back_update[0][0]
+        assert sp['layLiabilityTaken'][0]['price'] == sp_lay_update[0][0]

--- a/tests/test_streamingresources.py
+++ b/tests/test_streamingresources.py
@@ -394,3 +394,14 @@ class TestRunnerBook(unittest.TestCase):
         sp = serialise_d['sp']
         assert sp['backStakeTaken'][0]['price'] == sp_back_update[0][0]
         assert sp['layLiabilityTaken'][0]['price'] == sp_lay_update[0][0]
+
+    def test_empty_serialise(self):
+        serialise_d = self.runner_book.serialise(None)
+
+        ex = serialise_d['ex']
+        # all empty lists
+        assert all(not ex[a] for a in ex.keys())
+
+        sp = serialise_d['sp']
+        # all 'None' or empty lists
+        assert all(not sp[a] for a in sp.keys())

--- a/tests/test_streamingresources.py
+++ b/tests/test_streamingresources.py
@@ -382,9 +382,9 @@ class TestRunnerBook(unittest.TestCase):
         self.runner_book.update_starting_price_lay(sp_lay_update)
 
         serialise_d = self.runner_book.serialise(None)
-        assert serialise_d.keys() == \
-            ['status', 'totalMatched', 'adjustmentFactor', 'ex', 'handicap',
-             'lastPriceTraded', 'sp', 'selectionId']
+        assert set(serialise_d.keys()) == \
+            {'status', 'totalMatched', 'adjustmentFactor',
+             'lastPriceTraded', 'sp', 'ex', 'handicap', 'selectionId'}
 
         ex = serialise_d['ex']
         assert ex['tradedVolume'][0]['price'] == traded_update[0][0]


### PR DESCRIPTION
Hi Liam,

Additions and fixes so that the starting price object is available for the `RunnerBook`, without `sp` being available in the serialise function, was `RunnerBookSP` ever available?  The only thing I haven't changed (but maybe should do) is `RunnerBookSP`'s `actual_sp`.  I don't know what that should be per the exchange docs, http://docs.developer.betfair.com/docs/display/1smk3cen4v3lu3yomq5qye0ni/Exchange+Stream+API should it be removed?
