### PR TITLE
Set LimitOrder size to optional

### DIFF
--- a/betfairlightweight/resources/bettingresources.py
+++ b/betfairlightweight/resources/bettingresources.py
@@ -606,7 +606,7 @@ class LimitOrder(object):
     :type time_in_force: unicode
     """
 
-    def __init__(self, price, size, persistenceType=None, timeInForce=None, minFillSize=None, betTargetType=None,
+    def __init__(self, price, size=None, persistenceType=None, timeInForce=None, minFillSize=None, betTargetType=None,
                  betTargetSize=None):
         self.persistence_type = persistenceType
         self.price = price


### PR DESCRIPTION
Size isn't returned when bet_target_type is BACKERS_PROFIT.