### PR TITLE
Handle more BetFair parameter turbulence and updates to their API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ pip-log.txt
 nosetests.xml
 
 .DS_Store
+
+# IDE metafile ignores
+.idea

--- a/betfairlightweight/__init__.py
+++ b/betfairlightweight/__init__.py
@@ -6,7 +6,7 @@ from .streaming import StreamListener
 from . import filters
 
 __title__ = 'betfairlightweight'
-__version__ = '1.4.0'
+__version__ = '1.4.1'
 __author__ = 'Liam Pauling'
 
 # Set default logging handler to avoid "No handler found" warnings.

--- a/betfairlightweight/resources/bettingresources.py
+++ b/betfairlightweight/resources/bettingresources.py
@@ -160,7 +160,8 @@ class MarketCatalogueDescription(object):
 
     def __init__(self, bettingType, bspMarket, discountAllowed, marketBaseRate, marketTime, marketType,
                  persistenceEnabled, regulator, rules, rulesHasDate, suspendTime, turnInPlayEnabled, wallet,
-                 eachWayDivisor=None, clarifications=None):
+                 eachWayDivisor=None, clarifications=None,
+                 priceLadderDescription=None, keyLineDefinition=None):
         self.betting_type = bettingType
         self.bsp_market = bspMarket
         self.discount_allowed = discountAllowed
@@ -176,6 +177,8 @@ class MarketCatalogueDescription(object):
         self.wallet = wallet
         self.each_way_divisor = eachWayDivisor
         self.clarifications = clarifications
+        self.price_ladder_description = priceLadderDescription
+        self.key_line_definition = keyLineDefinition
 
 
 class RunnerCatalogue(object):

--- a/betfairlightweight/resources/bettingresources.py
+++ b/betfairlightweight/resources/bettingresources.py
@@ -529,8 +529,8 @@ class ClearedOrder(object):
     """
 
     def __init__(self, betId, betCount, betOutcome, eventId, eventTypeId, handicap, lastMatchedDate, marketId,
-                 orderType, persistenceType, placedDate, priceMatched, priceReduced, priceRequested, profit,
-                 selectionId, settledDate, side, sizeSettled, customerStrategyRef=None, customerOrderRef=None):
+                 orderType, persistenceType, placedDate, priceMatched, priceReduced, profit, selectionId,
+                 settledDate, side, sizeSettled, priceRequested=None, customerStrategyRef=None, customerOrderRef=None):
         self.bet_id = betId
         self.bet_count = betCount
         self.bet_outcome = betOutcome

--- a/betfairlightweight/resources/racecardresources.py
+++ b/betfairlightweight/resources/racecardresources.py
@@ -161,7 +161,7 @@ class Selection(object):
     :type selection_id: unicode
     """
 
-    def __init__(self, marketId, marketType, selectionId, bsp=None):
+    def __init__(self, marketId=None, marketType=None, selectionId=None, bsp=None):
         self.market_id = marketId
         self.market_type = marketType
         self.selection_id = selectionId

--- a/betfairlightweight/resources/streamingresources.py
+++ b/betfairlightweight/resources/streamingresources.py
@@ -76,7 +76,7 @@ class MarketDefinition(object):
                  openDate, persistenceEnabled, regulators, runnersVoidable, status, timezone, turnInPlayEnabled,
                  version, runners, countryCode=None, eachWayDivisor=None, venue=None, settledTime=None,
                  suspendTime=None, marketType=None, lineMaxUnit=None, lineMinUnit=None, lineInterval=None, name=None,
-                 eventName=None):
+                 eventName=None, priceLadderDescription=None, keyLineDefinition=None):
         self.bet_delay = betDelay
         self.betting_type = bettingType
         self.bsp_market = bspMarket
@@ -116,6 +116,8 @@ class MarketDefinition(object):
         self.runners_dict = {
             (runner.selection_id, runner.handicap): runner for runner in self.runners
         }
+        self.price_ladder_description = priceLadderDescription
+        self.key_line_definition = keyLineDefinition
 
 
 class Available(object):


### PR DESCRIPTION
Specifically needed for MarketDefinition and MarketCatalogueDescription.  `list_market_catalogue` is currently broken because of the latter, and the entire stream will be broken (if you've requested the MarketDefinition with your stream), when that update comes through.

The BetFair docs haven't updated to define `PriceLadderDescription`, nor `KeyLineDefinition` fully yet, but I'll put a new PR with the new objects for that when they do.

Some other oddities handled in other places as well.